### PR TITLE
[Feature]: Resolve #49 - Meta-Described Accessors

### DIFF
--- a/source/Magritte-Model.package/MAChainAccessor.class/instance/descriptionAccessor.st
+++ b/source/Magritte-Model.package/MAChainAccessor.class/instance/descriptionAccessor.st
@@ -1,0 +1,9 @@
+accessing-magritte
+descriptionAccessor
+	<magritteDescription>
+	^ MAToOneRelationDescription new
+			reference: MAStringDescription new;
+			accessor: #accessor;
+			classes: MAAccessor allSubclasses;
+			priority: 200;
+			yourself

--- a/source/Magritte-Model.package/MADelegatorAccessor.class/instance/descriptionNext.st
+++ b/source/Magritte-Model.package/MADelegatorAccessor.class/instance/descriptionNext.st
@@ -1,0 +1,9 @@
+accessing-magritte
+descriptionNext
+	<magritteDescription>
+	^ MAToOneRelationDescription new
+			reference: MAStringDescription new;
+			accessor: #next;
+			classes: MAAccessor allSubclasses;
+			priority: 100;
+			yourself

--- a/source/Magritte-Model.package/MADescription.class/instance/descriptionAccessor.st
+++ b/source/Magritte-Model.package/MADescription.class/instance/descriptionAccessor.st
@@ -1,0 +1,9 @@
+acessing-magritte
+descriptionAccessor
+	<magritteDescription>
+	^ MAToOneRelationDescription new
+		reference: MAStringDescription new;
+		accessor: #accessor;
+		classes: MAAccessor allSubclasses;
+		priority: 10;
+		yourself

--- a/source/Magritte-Model.package/MASelectorAccessor.class/instance/descriptionSelector.st
+++ b/source/Magritte-Model.package/MASelectorAccessor.class/instance/descriptionSelector.st
@@ -1,0 +1,6 @@
+accessing-magritte
+descriptionSelector
+	<magritteDescription>
+	^ MASymbolDescription new
+			accessor: #selector;
+			yourself

--- a/source/Magritte-Model.package/MAStringWriter.class/instance/visitClassDescription..st
+++ b/source/Magritte-Model.package/MAStringWriter.class/instance/visitClassDescription..st
@@ -1,3 +1,3 @@
 visiting-description
 visitClassDescription: aDescription
-	self stream nextPutAll: self object label
+	self stream nextPutAll: self object name


### PR DESCRIPTION
Example:
Given aDescription, like `MABooleanDescription new.`, you can now define an accessor via Magritte (e.g. a Morphic form).

As a test, let's try to use our description to read `Smalltalk os isMacOSX`:

1. In a MA Morphic form, click "Remove" for the current null accessor.
2. Now choose `MAChainAccessor` from the dropdown
3. In the popup form:
a. For the first accessor, choose `MASelectorAccessor` the dropdown and fill "os" into the edit field
b. For the second accessor, choose `MASelectorAccessor` the dropdown and fill "isMacOSX" into the edit field

Now, DoIt: `myDescription read: Smalltalk` "==> true | false"