### PR TITLE
[Feature]: Resolve #53 - Dynamic Condition Labels

### DIFF
--- a/source/Magritte-Model.package/BlockClosure.extension/instance/asMAConditionLabel.st
+++ b/source/Magritte-Model.package/BlockClosure.extension/instance/asMAConditionLabel.st
@@ -1,0 +1,3 @@
+*magritte-model-description
+asMAConditionLabel
+	^ self

--- a/source/Magritte-Model.package/MADescription.class/instance/addCondition.labelled..st
+++ b/source/Magritte-Model.package/MADescription.class/instance/addCondition.labelled..st
@@ -1,8 +1,8 @@
 validation
-addCondition: aCondition labelled: aString
+addCondition: aCondition labelled: aStringOrBlock
 	"Add ==aCondition== as an additional validation condition to the receiver and give it the label ==aString==. The first argument is either a block-context or any other object that responds to ==#value:== with ==true== or ==false==."
 
 	self conditions: (self conditions
 		copyWith: (Association
 			key: aCondition
-			value: aString))
+			value: aStringOrBlock asMAConditionLabel))

--- a/source/Magritte-Model.package/MADescription.class/instance/validateConditions..st
+++ b/source/Magritte-Model.package/MADescription.class/instance/validateConditions..st
@@ -4,4 +4,4 @@ validateConditions: anObject
 
 	self conditions do: [ :each |
 		(each key value: anObject)
-			ifFalse: [ MAConditionError description: self signal: each value ] ]
+			ifFalse: [ MAConditionError description: self signal: (each value cull: anObject) ] ]

--- a/source/Magritte-Model.package/String.extension/instance/asMAConditionLabel.st
+++ b/source/Magritte-Model.package/String.extension/instance/asMAConditionLabel.st
@@ -1,0 +1,3 @@
+*magritte-model
+asMAConditionLabel
+	^ [ self ]


### PR DESCRIPTION
Allow code like the following:
```smalltalk
"..."
addCondition: [ :obj | "whatever" ]
labelled: [ :obj | obj date mmddyyyy, ' is too far in the future'  ]
```