### PR TITLE
[Enh]: Fix #70 - Decoration Blocks - Component Arg Should Be Optional

### DIFF
--- a/source/Magritte-Seaside.package/MAContainerDecoration.class/instance/execute..st
+++ b/source/Magritte-Seaside.package/MAContainerDecoration.class/instance/execute..st
@@ -1,5 +1,5 @@
 actions
 execute: anObject
 	anObject isSymbol
-		ifFalse: [ anObject value: self decoratedComponent ]
+		ifFalse: [ anObject cull: self decoratedComponent ]
 		ifTrue: [ self decoratedComponent perform: anObject ]


### PR DESCRIPTION
For example, in `aComponent addValidatedForm: { [ self register ] -> 'Register' };`, the block doesn't require and argument