### PR TITLE
[Enh]: Fix #72 - Add `#fieldDescription`

### DIFF
--- a/source/Magritte-Model.package/MASelectorAccessor.class/instance/fieldDescription.st
+++ b/source/Magritte-Model.package/MASelectorAccessor.class/instance/fieldDescription.st
@@ -1,0 +1,3 @@
+printing
+fieldDescription
+	^ self readSelector asString


### PR DESCRIPTION
Sometimes you need a string representation of a field. For SelectorAccessors, it could easily be the readAccessor, for ChainAccessors maybe `firstSelector:secondSelector`, etc.