### PR TITLE
Fix #79 - Dynamic Options

### DIFF
--- a/source/Magritte-Model.package/Collection.extension/instance/maAllOptionsFor..st
+++ b/source/Magritte-Model.package/Collection.extension/instance/maAllOptionsFor..st
@@ -1,0 +1,3 @@
+*magritte-model-dynopt
+maAllOptionsFor: aDescription
+	^ aDescription prepareOptions: self copy

--- a/source/Magritte-Model.package/Collection.extension/instance/maSelectMatching..st
+++ b/source/Magritte-Model.package/Collection.extension/instance/maSelectMatching..st
@@ -1,0 +1,3 @@
+*magritte-model-dynopt
+maSelectMatching: aString 
+	^ self select: [ :e | e asString startsWith: aString ]

--- a/source/Magritte-Model.package/MADynamicOptions.class/class/block..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/class/block..st
@@ -1,0 +1,5 @@
+as yet unclassified
+block: aBlock
+	^ self new
+			block: aBlock;
+			yourself.

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/block..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/block..st
@@ -1,0 +1,3 @@
+as yet unclassified
+block: aBlock
+	block := aBlock

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/block.st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/block.st
@@ -1,0 +1,3 @@
+as yet unclassified
+block
+	^ block

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/detect..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/detect..st
@@ -1,0 +1,4 @@
+as yet unclassified
+detect: anObject
+	"Convert from a possibly-optimized object for entry-completion, to the object that should be saved"
+	^ self reader value: anObject

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/includes..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/includes..st
@@ -1,0 +1,3 @@
+as yet unclassified
+includes: anObject
+	^ includesBlock value: anObject

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/includesBlock..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/includesBlock..st
@@ -1,0 +1,3 @@
+as yet unclassified
+includesBlock: aBlock
+	includesBlock := aBlock

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/includesBlock.st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/includesBlock.st
@@ -1,0 +1,3 @@
+as yet unclassified
+includesBlock
+	^ includesBlock

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/maAllOptionsFor..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/maAllOptionsFor..st
@@ -1,0 +1,3 @@
+as yet unclassified
+maAllOptionsFor: anOptionDescription 
+	^ self

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/maSelectMatching..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/maSelectMatching..st
@@ -1,0 +1,3 @@
+as yet unclassified
+maSelectMatching: aString 
+	^ self block value: aString

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/reader..st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/reader..st
@@ -1,0 +1,3 @@
+as yet unclassified
+reader: aBlock
+	completionToObjectBlock := aBlock

--- a/source/Magritte-Model.package/MADynamicOptions.class/instance/reader.st
+++ b/source/Magritte-Model.package/MADynamicOptions.class/instance/reader.st
@@ -1,0 +1,3 @@
+as yet unclassified
+reader
+	^ completionToObjectBlock ifNil: [ [ :obj | obj ] ]

--- a/source/Magritte-Model.package/MADynamicOptions.class/properties.json
+++ b/source/Magritte-Model.package/MADynamicOptions.class/properties.json
@@ -1,0 +1,16 @@
+{
+	"category" : "Magritte-Model-Utility",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"block",
+		"completionToObjectBlock",
+		"includesBlock" ],
+	"name" : "MADynamicOptions",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"type" : "normal" }

--- a/source/Magritte-Model.package/MAOptionDescription.class/instance/allOptions.st
+++ b/source/Magritte-Model.package/MAOptionDescription.class/instance/allOptions.st
@@ -1,3 +1,3 @@
 accessing-dynamic
 allOptions
-	^ self prepareOptions: self options copy
+	^ self options maAllOptionsFor: self


### PR DESCRIPTION
* e.g. options are results from Google Places matching the input
* Override PluggableTextFieldMorph while [discussing on mailing
* list](http://forum.world.st/PluggableTextFieldMorph-Entry-Completion-Enhancement-td4901577.html)
* Based on Magritte-Model-SeanDeNigris.468

Dynamic Options: Allow Optimized Completion Objects

Google Places, for example, uses one lightweight object for
autocompletion, and another with full details.

We offer a mapping between the object we're using for completion, and
the object it really represents (that should be ultimately stored)