### PR TITLE
94-Is-there-a-reason-to-have-so-many-groups-from-Seaside

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -1,13 +1,11 @@
 baselines
 baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
+
 	spec
-		baseline: 'Grease' with: [ 
-			spec 
-				repository: 'github://SeasideSt/Grease:1.3.5/repository' ];
-			
-		baseline: 'Seaside3' with: [ 
-				"note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded" 
-					spec 
-						repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
-						loads: #('Core' 'Javascript' 'RSS' 'Filesystem' 'Welcome' ) ]
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.3.5/repository' ];
+		baseline: 'Seaside3'
+			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
+			spec
+				repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
+				loads: #('Core') ]


### PR DESCRIPTION
We only needs the Core group from Seaside. 

Fixes #94