### PR TITLE
Update Seaside and Grease versions

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -3,7 +3,7 @@ baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.4.2/repository' ];
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.4.2/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec

--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -3,7 +3,7 @@ baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.4.1/repository' ];
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.4.2/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec

--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -3,9 +3,9 @@ baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.3.5/repository' ];
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.4.1/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
-				repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
+				repository: 'github://SeasideSt/Seaside:v3.3.1/repository';
 				loads: #('Core') ]


### PR DESCRIPTION
Magritte currently depends on the old version of Seaside and Grease. The version of Seaside is bugged. 

Here is a PR to fix that.