### PR TITLE
[Enh]: Smalltalk Block Description

### DIFF
--- a/source/Magritte-Model.package/MABlockDescription.class/class/defaultKind.st
+++ b/source/Magritte-Model.package/MABlockDescription.class/class/defaultKind.st
@@ -1,0 +1,3 @@
+accessing-defaults
+defaultKind
+	^ BlockClosure

--- a/source/Magritte-Model.package/MABlockDescription.class/class/defaultMorphClasses.st
+++ b/source/Magritte-Model.package/MABlockDescription.class/class/defaultMorphClasses.st
@@ -1,0 +1,3 @@
+as yet unclassified
+defaultMorphClasses
+	^ Array with: MAMemoMorph

--- a/source/Magritte-Model.package/MABlockDescription.class/class/isAbstract.st
+++ b/source/Magritte-Model.package/MABlockDescription.class/class/isAbstract.st
@@ -1,0 +1,3 @@
+testing
+isAbstract
+	^ false

--- a/source/Magritte-Model.package/MABlockDescription.class/class/label.st
+++ b/source/Magritte-Model.package/MABlockDescription.class/class/label.st
@@ -1,0 +1,3 @@
+accessing
+label
+	^ 'Block'

--- a/source/Magritte-Model.package/MABlockDescription.class/instance/acceptMagritte..st
+++ b/source/Magritte-Model.package/MABlockDescription.class/instance/acceptMagritte..st
@@ -1,0 +1,3 @@
+visiting
+acceptMagritte: aVisitor
+	aVisitor visitBlockDescription: self

--- a/source/Magritte-Model.package/MABlockDescription.class/properties.json
+++ b/source/Magritte-Model.package/MABlockDescription.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "MAElementDescription",
+	"category" : "Magritte-Model-Description",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "MABlockDescription",
+	"type" : "normal"
+}

--- a/source/Magritte-Model.package/MAStringReader.class/instance/visitBlockDescription..st
+++ b/source/Magritte-Model.package/MAStringReader.class/instance/visitBlockDescription..st
@@ -1,0 +1,3 @@
+visiting-description
+visitBlockDescription: aDescription
+	self object: (Smalltalk compiler evaluate: self contents)

--- a/source/Magritte-Model.package/MAVisitor.class/instance/visitBlockDescription..st
+++ b/source/Magritte-Model.package/MAVisitor.class/instance/visitBlockDescription..st
@@ -1,0 +1,3 @@
+visiting-description
+visitBlockDescription: anObject
+	self visitElementDescription: anObject


### PR DESCRIPTION
*NB*: Conversion from string requires code evaluation, which can pose a big security risk. Use with caution.

We duplicated MAMemoDescription's multi-line behavior. It would be nice to extract into a Trait to avoid the duplication, but we'll hold off in the interest of cross-platform compatibility since it's "just a few methods"

Fix Issue #97