### PR TITLE
Update Magritte to use the Master of grease instead of a specific version

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -4,10 +4,10 @@ baseline310CommonExtDeps: spec
 
 	spec
 		baseline: 'Grease'
-			with: [ spec repository: 'github://SeasideSt/Grease:Master/repository' ];
+			with: [ spec repository: 'github://SeasideSt/Grease:master/repository' ];
 		baseline: 'Seaside3'
 			with:
 				[ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
-				repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
+				repository: 'github://SeasideSt/Seaside:master/repository';
 				loads: #('Core') ]

--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -1,11 +1,13 @@
 baselines
 baseline310CommonExtDeps: spec
-	"Common external dependencies for baseline 3.1.0"
+	"Common external dependencies for baseline 3.1.0.  Use Master instead of 1.3.5"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.3.5/repository' ];
+		baseline: 'Grease'
+			with: [ spec repository: 'github://SeasideSt/Grease:Master/repository' ];
 		baseline: 'Seaside3'
-			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
+			with:
+				[ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
 				repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
 				loads: #('Core') ]


### PR DESCRIPTION
Pier needs to load both Seaside and Magritte.  Since Magritte requires version 1.3.5 instead of Master, it fails to load.  Incidentally AFAIK version 1.3.5 is the current master, so it shouldn't impact other projects.