### PR TITLE
Update baseline310CommonExtDeps..st

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -3,9 +3,9 @@ baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:1.3.5/repository' ];
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
-				repository: 'github://SeasideSt/Seaside:v3.2.4/repository';
+				repository: 'github://SeasideSt/Seaside/repository';
 				loads: #('Core') ]


### PR DESCRIPTION
Removed versions in Baseline, as this causes Magritte not to load under Pharo 6 and 7. This Seaside baseline still does not define the tags #Pharo6.x and #Pharo7.x