### PR TITLE
Fields with Multiple Aspects (i.e. Alternate Descriptions)

### DIFF
--- a/source/Magritte-Model.package/Object.extension/instance/magritteAllDescriptionsFor..st
+++ b/source/Magritte-Model.package/Object.extension/instance/magritteAllDescriptionsFor..st
@@ -1,6 +1,6 @@
 *Magritte-Model
 magritteAllDescriptionsFor: aDescriptionSelector
-	"Experiment: What if our object has a field that can be thought of in different ways? For example, a messages field that can be filtered into #read, #unread, and #all. #descriptionMessages would be the actual description, and then there could be a #descriptionUnreadMessages and #descriptionReadMessages which are dcescriptions of the filtered collections. By annotating these alternate descriptions with <magritteAltFor: #descriptionMessages order: aNumber>, these could be e.g. displayed as tabs in a Magritte form"
+	"Experiment: What if our object has a field that can be thought of in different ways? For example, a messages field that can be filtered into #read, #unread, and #all. #descriptionMessages would be the actual description, and then there could be a #descriptionUnreadMessages and #descriptionReadMessages which are dcescriptions of the filtered collections. By annotating these alternate descriptions with <magritteAltFor: #descriptionMessages>, these could be e.g. displayed as tabs in a Magritte form"
 	
 	^ OrderedCollection new
 			add: (self perform: aDescriptionSelector);

--- a/source/Magritte-Model.package/Object.extension/instance/magritteAllDescriptionsFor..st
+++ b/source/Magritte-Model.package/Object.extension/instance/magritteAllDescriptionsFor..st
@@ -1,0 +1,9 @@
+*Magritte-Model
+magritteAllDescriptionsFor: aDescriptionSelector
+	"Experiment: What if our object has a field that can be thought of in different ways? For example, a messages field that can be filtered into #read, #unread, and #all. #descriptionMessages would be the actual description, and then there could be a #descriptionUnreadMessages and #descriptionReadMessages which are dcescriptions of the filtered collections. By annotating these alternate descriptions with <magritteAltFor: #descriptionMessages order: aNumber>, these could be e.g. displayed as tabs in a Magritte form"
+	
+	^ OrderedCollection new
+			add: (self perform: aDescriptionSelector);
+			addAll: (self magritteAlternatesFor: aDescriptionSelector);
+			sort;
+			yourself

--- a/source/Magritte-Model.package/Object.extension/instance/magritteAlternatesFor..st
+++ b/source/Magritte-Model.package/Object.extension/instance/magritteAlternatesFor..st
@@ -1,0 +1,9 @@
+*Magritte-Model
+magritteAlternatesFor: aDescriptionSelector
+	| altDescriptionMethods relevantDescMeths |
+	altDescriptionMethods := Pragma
+		allNamed: #magritteAltFor:
+		from: self class
+		to: Object.
+	relevantDescMeths := altDescriptionMethods select: [ :p | p arguments first = aDescriptionSelector ].
+	^ relevantDescMeths collect: [ :m | self perform: m method selector ]


### PR DESCRIPTION
What if our object has a field that can be thought of in different ways? For example, a messages field that can be filtered into `#read`, `#unread`, and `#all`. `#descriptionMessages` would be the actual description, and then there could be a `#descriptionUnreadMessages` and `#descriptionReadMessages` which are descriptions of the filtered collections. By annotating these alternate descriptions with `<magritteAltFor: #descriptionMessages>`, these could be e.g. displayed as tabs in a Magritte form.