### PR TITLE
enh/cache-on-access-toggle

### DIFF
--- a/source/Magritte-Model.package/MADescription.class/class/defaultShouldCacheDefault.st
+++ b/source/Magritte-Model.package/MADescription.class/class/defaultShouldCacheDefault.st
@@ -1,0 +1,3 @@
+accessing-defaults
+defaultShouldCacheDefault
+	^ false

--- a/source/Magritte-Model.package/MADescription.class/instance/shouldCacheDefault.st
+++ b/source/Magritte-Model.package/MADescription.class/instance/shouldCacheDefault.st
@@ -1,0 +1,4 @@
+accessing-properties
+shouldCacheDefault
+
+	^ self propertyAt: #shouldCacheDefault ifAbsent: [ self class defaultShouldCacheDefault ]

--- a/source/Magritte-Model.package/MAToManyRelationDescription.class/class/defaultShouldCacheDefault.st
+++ b/source/Magritte-Model.package/MAToManyRelationDescription.class/class/defaultShouldCacheDefault.st
@@ -1,0 +1,3 @@
+accessing-defaults
+defaultShouldCacheDefault
+	^ true

--- a/source/Magritte-Model.package/Object.extension/instance/maLazyFrom..st
+++ b/source/Magritte-Model.package/Object.extension/instance/maLazyFrom..st
@@ -2,7 +2,7 @@
 maLazyFrom: description
 	"Return the current value of a field as specified by its description
 		- NB: Only works with a selector accessor with matching inst var name e.g. (readSelector = instVarName = #myField). It could be extended to other cases if the need arises.
-		- The default value is not cached. If necessary, another variant could be added to do that.
+		- The default value is cached if the description's #shouldCacheDefault property is true. An example when caching is necessary is for to-many relations because the user may modify the collection, which will then be thrown away if not cached
 
 	Usage: 
 		MyDomainObject>>#getter
@@ -14,6 +14,9 @@ maLazyFrom: description
 					default: 'Alan';
 					yourself"
 
-	| currentValue |
+	| currentValue defaultValue |
 	currentValue := self instVarNamed: description accessor readSelector.
-	^ currentValue ifNil: [ description default ].
+	currentValue ifNotNil: [ ^ currentValue ].
+	defaultValue := description default.
+	description shouldCacheDefault ifTrue: [ self write: defaultValue using: description ].
+	^ defaultValue.


### PR DESCRIPTION
[Enh]: Description Cache-on-access

This is needed for `#maLazyFrom:` because, e.g. for accessors returning collections, the user may modify the collection, which will then be thrown away if not cached