### PR TITLE
Updated for Pharo 9

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline310CommonExtDeps..st
@@ -3,7 +3,7 @@ baseline310CommonExtDeps: spec
 	"Common external dependencies for baseline 3.1.0"
 
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.4.x/repository' ];
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.5.x/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec

--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
@@ -29,17 +29,7 @@ baseline330ForPharo: spec
 				" create a temporary alias "
 				package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo3-Model'].
 	spec
-		for: #(#'pharo7.x')
-		do: [ 
-			spec
-				package: 'Magritte-Pharo7-Model' with: [ spec requires: #('Magritte-Model') ];
-				package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo7-Model') ];
-				package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo7-Model') ];
-				" create a temporary alias "
-				package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo7-Model'].
-
-	spec
-		for: #(#'pharo8.x')
+		for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x')
 		do: [ 
 			spec
 				package: 'Magritte-Pharo7-Model' with: [ spec requires: #('Magritte-Model') ];

--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
@@ -51,7 +51,7 @@ baseline330ForPharo: spec
 			spec package: 'Magritte-Morph' with: [ spec includes: #('Magritte-GT') ].
 			spec group: 'default' with: #('Magritte-GT') ].
 	spec
-		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x')
+		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x' #'pharo9.x')
 		do: [ 
 			spec
 				baseline: 'PharoEnhancements' with: [


### PR DESCRIPTION
Updated baseline so that Magritte loads correctly into Pharo 9 and load current version of Grease (1.5.x) that will be compatible with Pharo 9 (is not yet, but Grease PR is being reviewed: https://github.com/SeasideSt/Grease/pull/99 ).
Solves #141 