### PR TITLE
Exchanged sections for pharo7,8,9 with the general #pharo release. Th…

### DIFF
--- a/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
+++ b/source/BaselineOfMagritte.package/BaselineOfMagritte.class/instance/baseline330ForPharo..st
@@ -29,7 +29,7 @@ baseline330ForPharo: spec
 				" create a temporary alias "
 				package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo3-Model'].
 	spec
-		for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x')
+		for: #(#'pharo')
 		do: [ 
 			spec
 				package: 'Magritte-Pharo7-Model' with: [ spec requires: #('Magritte-Model') ];
@@ -51,7 +51,7 @@ baseline330ForPharo: spec
 			spec package: 'Magritte-Morph' with: [ spec includes: #('Magritte-GT') ].
 			spec group: 'default' with: #('Magritte-GT') ].
 	spec
-		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x' #'pharo9.x')
+		for: #(#'pharo5.x' #'pharo6.x' #'pharo')
 		do: [ 
 			spec
 				baseline: 'PharoEnhancements' with: [


### PR DESCRIPTION
…is is valid until it is not :) So we change if needed not always.

We always need to create new sections in pharo without need. The general version #pharo does that until it needs adjustment. Then we can fix pharo to all versions up to the conflicting one and make the new one #pharo