### PR TITLE
[Bug]: Fixes for Pharo 9

### DIFF
--- a/source/Magritte-Developer.package/Object.extension/class/maAddField.with..st
+++ b/source/Magritte-Developer.package/Object.extension/class/maAddField.with..st
@@ -7,7 +7,7 @@ maAddField: aSymbol with: customizationBlock
 		customizationBlock - takes description as argument; hook to modify it before it is serialized as a constructor method"
 
 	| elementTypes aClass |
-	elementTypes := MAElementDescription allSubclasses sort: [ :a :b | a name > b name ].
+	elementTypes := MAElementDescription allSubclasses sort: [ :a :b | a name < b name ].
 	aClass := UIManager default 
 		chooseFrom: (elementTypes collect: #name)
 		values: elementTypes

--- a/source/Magritte-Morph.package/MAMemoMorph.class/instance/buildMorphView.st
+++ b/source/Magritte-Morph.package/MAMemoMorph.class/instance/buildMorphView.st
@@ -3,7 +3,7 @@ buildMorphView
 	"The selector #annotation should be #string instead, but we use this one and dispatch since this prevents morphic to draw a thin red border around changed fields. Stupid hack, really, but doesn't work otherwise."
 
 	| result lineSpacingFactor height |
-	result := PluggableTextMorph on: self text: #annotation accept: #string:.
+	result := RubPluggableTextMorph on: self text: #annotation accept: #string: readSelection: nil menu: nil.
 	
 	"We want to set the height to honor the #lineCount from the description, but PluggableTextMorph doesn't seem to have an API to get the height of a hypothetical block of text e.g. 5 lines in the current font. So we work out an approximation as follows..."
 	lineSpacingFactor := 1.1. "This seems to account well for space between lines"

--- a/source/Magritte-Morph.package/TokenCollectorMorph.class/instance/accept..st
+++ b/source/Magritte-Morph.package/TokenCollectorMorph.class/instance/accept..st
@@ -2,7 +2,7 @@ private
 accept: text
 	| object |
 	object := self options
-		detect: [ :e | self stringDecoder value: e value: text ]
+		detect: [ :e | self stringDecoder value: e value: text asString ]
 		ifNone: [ factory value: text ].
 	self objects add: object.
 	whenObjectsChangedBlock ifNotNil: [ :blk | blk value: self objects ].


### PR DESCRIPTION
- When adding field, list description classes ascending alpha
- Use RubPluggableTextMorph for MemoMorphs (it replaced PluggableTextMorph in P9 per http://forum.world.st/pharo8-api-change-newTextEditor-tt5112654.html) <- this one is the only change that seems not to be infinitely backward compatible. It works in P8 for sure. I say we let it go and see if anyone complains?! I always wonder if there are even users of super old platforms using our code...
- TokenCollectorMorph was comparing text to string