### PR TITLE
bug/morphic-relations-need-ordered-class-collection

### DIFF
--- a/source/Magritte-Morph.package/MARelationMorph.class/instance/classes.st
+++ b/source/Magritte-Morph.package/MARelationMorph.class/instance/classes.st
@@ -1,4 +1,4 @@
 accessing-dynamic
 classes
 
-	^ self magritteDescription classes.
+	^ self magritteDescription classes asSortedCollection.


### PR DESCRIPTION
[Bug]: Morphic Relations `#classes` Collection Must Be Ordered

They use the index to manage selection, which leads to DNU for e.g. Sets