### PR TITLE
Printing Convenience, Including a Test

### DIFF
--- a/source/Magritte-Model.package/MAElementDescription.class/instance/printFor.on..st
+++ b/source/Magritte-Model.package/MAElementDescription.class/instance/printFor.on..st
@@ -1,0 +1,3 @@
+*magritte-model
+printFor: anObject on: aWriteStream 
+	(self read: anObject) ifNotNil: [ :value | aWriteStream nextPutAll: value asString ]

--- a/source/Magritte-Model.package/WriteStream.extension/instance/maPrint.for..st
+++ b/source/Magritte-Model.package/WriteStream.extension/instance/maPrint.for..st
@@ -1,0 +1,42 @@
+*magritte-model
+maPrint: anMADescription for: anObject
+	anMADescription printFor: anObject on: self
+	
+	"# Motivation: Printing Convenience
+
+Typically, `#printOn:` and friends have a lot of nil checks sprinkled around. Modern Pharo's tools are typically robust to printString errors, but you still get a not-very-helpful ""error printing"" message. Here comes Magritte to the rescue with `WriteStream >> #maPrint:for:`. 
+
+Here's an example:
+```smalltalk
+printOn: aStream
+	aStream 
+		maPrint: self descriptionDescription for: self;
+		nextPutAll: 'whatever'.
+```
+This reads the value and behaves gracefully if it is unset (by doing nothing). Notice that it also fits into the typical cascade without breaking it into multiple statements.
+
+Without this the options are not as nice...
+
+## Old (Typical) Pattern
+Nil checks everywhere...
+```smalltalk
+printOn: aStream
+	description ifNotNil: [ :desc | aStream nextPutAll: desc ]
+	""repeated for each relevant field""
+```
+## Naive Magritte Fix
+You might just supply a reasonable default value for each description, like:
+```smalltalk
+descriptionDescription
+	<magritteDescription>
+	^ MAStringDescription new
+		accessor: #description;
+		default: '';
+		yourself
+```
+which allows you to simplify to:
+```smalltalk
+printOn: aStream
+	aStream nextPutAll: self description.
+```
+However, that requires cluttering descriptions with default values which may not fit the domain."

--- a/source/Magritte-Model.package/WriteStream.extension/properties.json
+++ b/source/Magritte-Model.package/WriteStream.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "WriteStream"
+}

--- a/source/Magritte-Tests-Model.package/MAExtensionsTest.class/instance/testPrintingConvenience.st
+++ b/source/Magritte-Tests-Model.package/MAExtensionsTest.class/instance/testPrintingConvenience.st
@@ -1,0 +1,21 @@
+tests-string
+testPrintingConvenience
+
+	| result table |
+	table := {
+		{ MAStringDescription new
+				accessor: #asString;
+				yourself.
+			self asString }.
+		{ MAElementDescription new
+				accessor: (MAPluggableAccessor new readBlock: [ :obj | nil ]);
+				yourself.
+			'' } }.
+	
+	table do: [ :data | 
+		| description expected |
+		description := data first.
+		expected := data second.
+		result := String streamContents: [ :str | str maPrint: description for: self ].
+
+		self assert: result equals: expected ].


### PR DESCRIPTION
Typically, `#printOn:` and friends have a lot of nil checks sprinkled around. Modern Pharo's tools are typically robust to printString errors, but you still get a not-very-helpful "error printing" message. Here comes Magritte to the rescue with `WriteStream >> #maPrint:for:`. 

Here's an example:
```smalltalk
printOn: aStream
	aStream 
		maPrint: self descriptionDescription for: self;
		nextPutAll: 'whatever'.
```
This reads the value and behaves gracefully if it is unset (by doing nothing). Notice that it also fits into the typical cascade without breaking it into multiple statements.

Without this the options are not as nice...

## Old (Typical) Pattern
Nil checks everywhere...
```smalltalk
printOn: aStream
	description ifNotNil: [ :desc | aStream nextPutAll: desc ]
	"repeated for each relevant field"
```
## Naive Magritte Fix
You might just supply a reasonable default value for each description, like:
```smalltalk
descriptionDescription
	<magritteDescription>
	^ MAStringDescription new
		accessor: #description;
		default: '';
		yourself
```
which allows you to simplify to:
```smalltalk
printOn: aStream
	aStream nextPutAll: self description.
```
However, that requires cluttering descriptions with default values which may not fit the domain.