### PR TITLE
GT Inspector Extension - Always Show

### DIFF
--- a/source/Magritte-GT.package/Object.extension/instance/gtInspectorMagritteIn..st
+++ b/source/Magritte-GT.package/Object.extension/instance/gtInspectorMagritteIn..st
@@ -1,7 +1,4 @@
 *Magritte-GT
 gtInspectorMagritteIn: composite
 	<gtInspectorPresentationOrder: 40>
-	composite magritte
-		title: 'Form';
-		display: [ self ];
-		when: [ self magritteDescription isContainer not or: [ self magritteDescription notEmpty ] ]
+	composite magritte title: 'Magritte'


### PR DESCRIPTION
Makes sense because there are always at least the default Object actions to show