### PR TITLE
Refactor - Move #maPrintOn: to Container

### DIFF
--- a/source/Magritte-Model.package/MAContainer.class/instance/print.on..st
+++ b/source/Magritte-Model.package/MAContainer.class/instance/print.on..st
@@ -1,0 +1,14 @@
+accessing
+print: anObject on: aStream
+	"Print the current values of all anObject's described fields. Customize the printing of a field with the #maPrintString property, which should store a valuable with the value of the field as an optional argument"
+	self
+		do: [ :d | 
+			| value |
+			value := d read: anObject.
+			value ifNotNil: [ | stringValue |
+				stringValue := d
+					propertyAt: #maPrintString
+					ifPresent: [ :map | map cull: value ]
+					ifAbsent: [ d toString: value ].
+				aStream nextPutAll: stringValue ] ]
+		separatedBy: [ aStream space ]

--- a/source/Magritte-Model.package/Object.extension/instance/maPrintOn..st
+++ b/source/Magritte-Model.package/Object.extension/instance/maPrintOn..st
@@ -1,16 +1,3 @@
 *Magritte-Model
-maPrintOn: aStream
-	"Print the current values of all described fields. Customize the printing of a field with the #maPrintString property, which should store a valuable with the value of the field as an optional argument"
-	
-	self magritteDescription
-		do: [ :d | 
-			| value |
-			value := d read: self.
-			value ifNotNil: [ 
-				| stringValue |
-				stringValue := d 
-					propertyAt: #maPrintString
-					ifPresent: [ :map | map cull: value ]
-					ifAbsent: [ d toString: value ].
-				aStream nextPutAll: stringValue ] ]
-		separatedBy: [ aStream space ]
+maPrintOn: aStream	
+	self magritteDescription print: self on: aStream


### PR DESCRIPTION
Allows customization without Object API explosion