### PR TITLE
Boolean String Reading Should Be Case Insensitive

### DIFF
--- a/source/Magritte-Model.package/MAStringReader.class/instance/isFalseUsing..st
+++ b/source/Magritte-Model.package/MAStringReader.class/instance/isFalseUsing..st
@@ -1,0 +1,4 @@
+private
+isFalseUsing: aDescription
+	^ aDescription falseString = self contents
+		or: [ aDescription falseStrings anySatisfy: [ :e | e asLowercase = self contents asLowercase ] ]

--- a/source/Magritte-Model.package/MAStringReader.class/instance/isTrueUsing..st
+++ b/source/Magritte-Model.package/MAStringReader.class/instance/isTrueUsing..st
@@ -1,0 +1,4 @@
+private
+isTrueUsing: aDescription
+	^ aDescription trueString = self contents
+		or: [ aDescription trueStrings anySatisfy: [ :e | e asLowercase = self contents asLowercase ] ]

--- a/source/Magritte-Model.package/MAStringReader.class/instance/visitBooleanDescription..st
+++ b/source/Magritte-Model.package/MAStringReader.class/instance/visitBooleanDescription..st
@@ -1,9 +1,7 @@
 visiting-description
 visitBooleanDescription: aDescription
-	(aDescription trueString = self contents
-		or: [ aDescription trueStrings includes: self contents ])
+	(self isTrueUsing: aDescription)
 			ifTrue: [ ^ self object: true ].
-	(aDescription falseString = self contents
-		or: [ aDescription falseStrings includes: self contents ])
+	(self isFalseUsing: aDescription)
 			ifTrue: [ ^ self object: false ].
 	MAReadError signal

--- a/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testCaseInsensitiveStrings.convertTo..st
+++ b/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testCaseInsensitiveStrings.convertTo..st
@@ -1,0 +1,7 @@
+private
+testCaseInsensitiveStrings: aCollection convertTo: aBoolean
+	| lowercaseStrings uppercaseStrings |
+	lowercaseStrings := aCollection.
+	uppercaseStrings := lowercaseStrings collect: [ :e | e asUppercase ].
+	lowercaseStrings, uppercaseStrings do: [ :e | 
+		self assert: (self description fromString: e) = aBoolean ]

--- a/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testFalseStrings.st
+++ b/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testFalseStrings.st
@@ -1,0 +1,3 @@
+tests
+testFalseStrings
+	self testCaseInsensitiveStrings: #( 'false' 'f' 'no' 'n' '0' 'off' ) convertTo: false

--- a/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testTrueStrings.st
+++ b/source/Magritte-Tests-Model.package/MABooleanDescriptionTest.class/instance/testTrueStrings.st
@@ -1,0 +1,3 @@
+tests
+testTrueStrings
+	self testCaseInsensitiveStrings: #( 'true' 't' 'yes' 'y' '1' 'on' ) convertTo: true


### PR DESCRIPTION
- e.g. both 'f' and 'F' should be read as `false`
- Add a test; fails without fix and passes with
- Changed for default strings, but explicitly set string (e.g. via `#falseString:` still compared via #= because it's not clear what user intention would be in that case; may change in the future based on experience