### PR TITLE
Feature: GtDocument from anMAStringDescription

### DIFF
--- a/source/Magritte-GToolkit.package/GtDocument.extension/class/maFor.using..st
+++ b/source/Magritte-GToolkit.package/GtDocument.extension/class/maFor.using..st
@@ -1,0 +1,10 @@
+*Magritte-GToolkit
+maFor: anObject using: aDescription
+	| s |
+	s := MAGtDescriptionStorageStrategy new
+		description: aDescription;
+		object: anObject;
+		yourself.
+	^ self new 
+		strategy: s;
+		read

--- a/source/Magritte-GToolkit.package/GtDocument.extension/properties.json
+++ b/source/Magritte-GToolkit.package/GtDocument.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "GtDocument"
+}

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/description..st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/description..st
@@ -1,0 +1,3 @@
+accessing
+description: anObject
+	description := anObject

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/description.st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/description.st
@@ -1,0 +1,3 @@
+accessing
+description
+	^ description

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/object..st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/object..st
@@ -1,0 +1,3 @@
+accessing
+object: anObject
+	object := anObject

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/object.st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/object.st
@@ -1,0 +1,3 @@
+accessing
+object
+	^ object

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/read..st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/read..st
@@ -1,0 +1,3 @@
+accessing
+read: aGtDocument
+	^ aGtDocument text: (self description read: self object)

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/rootDirectory.st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/rootDirectory.st
@@ -1,0 +1,4 @@
+accessing
+rootDirectory
+	<return: #FileReference>
+	^ FileSystem workingDirectory

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/save..st
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/instance/save..st
@@ -1,0 +1,3 @@
+accessing
+save: aGtDocument 
+	self description write: aGtDocument text asString to: self object

--- a/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/properties.json
+++ b/source/Magritte-GToolkit.package/MAGtDescriptionStorageStrategy.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"commentStamp" : "",
+	"super" : "GtStorageStrategy",
+	"category" : "Magritte-GToolkit",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"description",
+		"object"
+	],
+	"name" : "MAGtDescriptionStorageStrategy",
+	"type" : "normal"
+}


### PR DESCRIPTION
Similar to ${class:GtDocumenter}$''s built-in ability to store documents in class comments via ${method:GtDocument class>>#forClass:}$, you can view and edit fields described by ${class:MAStringDescription}$. For example: ==GtDocument maFor: recipe using: self noteDescription.==