### PR TITLE
Gt Document Support: Update Due to GT Deprecation

### DIFF
--- a/source/Magritte-GToolkit/GtDocumenter.extension.st
+++ b/source/Magritte-GToolkit/GtDocumenter.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #GtDocumenter }
+
+{ #category : #'*Magritte-GToolkit' }
+GtDocumenter class >> maFor: anObject using: aDescription [
+	| result |
+	result := self new.
+	result editorElement maFor: anObject using: aDescription.
+	^ result read
+]

--- a/source/Magritte-GToolkit/GtDocumenterEditor.extension.st
+++ b/source/Magritte-GToolkit/GtDocumenterEditor.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #GtDocumenterEditor }
+
+{ #category : #'*Magritte-GToolkit' }
+GtDocumenterEditor >> maFor: anObject using: aMADescription [ 
+	storageModel maFor: anObject using: aMADescription
+]

--- a/source/Magritte-GToolkit/GtDocumenterEditorStorageModel.extension.st
+++ b/source/Magritte-GToolkit/GtDocumenterEditorStorageModel.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #GtDocumenterEditorStorageModel }
+
+{ #category : #'*Magritte-GToolkit' }
+GtDocumenterEditorStorageModel >> maFor: anObject using: aDescription [ 
+	| s |
+	s := MAGtDescriptionStorageStrategy new
+		description: aDescription;
+		object: anObject;
+		yourself.
+	self storage: s
+]

--- a/source/Magritte-GToolkit/MAGtDescriptionStorageStrategy.class.st
+++ b/source/Magritte-GToolkit/MAGtDescriptionStorageStrategy.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : #MAGtDescriptionStorageStrategy,
+	#superclass : #GtStorageStrategy,
+	#instVars : [
+		'description',
+		'object'
+	],
+	#category : #'Magritte-GToolkit'
+}
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> description [
+	^ description
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> description: anObject [
+	description := anObject
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> object [
+	^ object
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> object: anObject [
+	object := anObject
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> read: aGtDocument [
+	^ aGtDocument text: (self description read: self object)
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> rootDirectory [
+	<return: #FileReference>
+	^ FileSystem workingDirectory
+]
+
+{ #category : #accessing }
+MAGtDescriptionStorageStrategy >> save: aGtDocument [ 
+	self description write: aGtDocument text asString to: self object
+]


### PR DESCRIPTION
- GtDocument has been deprecated in favor of GtDocumenter
- Much of this code was originally committed in 80b6611, but after several merges, by cc476c1 it was missing