### PR TITLE
[Enh]: Description `undefinedValue` Property

### DIFF
--- a/source/Magritte-Model/MADescription.class.st
+++ b/source/Magritte-Model/MADescription.class.st
@@ -101,6 +101,11 @@ MADescription class >> defaultUndefined [
 ]
 
 { #category : #'accessing-defaults' }
+MADescription class >> defaultUndefinedValue [
+	^ nil
+]
+
+{ #category : #'accessing-defaults' }
 MADescription class >> defaultValidator [
 	^ MAValidatorVisitor
 ]
@@ -276,7 +281,7 @@ MADescription >> conflictErrorMessage: aString [
 
 { #category : #accessing }
 MADescription >> default [
-	^ nil
+	^ self undefinedValue
 ]
 
 { #category : #accessing }
@@ -439,6 +444,16 @@ MADescription >> descriptionUndefined [
 		label: 'Undefined String';
 		priority: 140;
 		default: self class defaultUndefined;
+		yourself
+]
+
+{ #category : #'acessing-magritte' }
+MADescription >> descriptionUndefinedValue [
+	<magritteDescription>
+	^ MAToOneRelationDescription new
+		accessor: #undefinedValue;
+		priority: 150;
+		default: self class defaultUndefinedValue;
 		yourself
 ]
 
@@ -805,6 +820,18 @@ MADescription >> undefined [
 { #category : #'accessing-strings' }
 MADescription >> undefined: aString [
 	self propertyAt: #undefined put: aString
+]
+
+{ #category : #'accessing-properties' }
+MADescription >> undefinedValue [
+	self flag: 'could this be simplified with maLazyXyz?'.
+	^ (self propertyAt: #undefinedValue ifAbsent: [ self class defaultUndefinedValue ])
+		ifNil: [ self class defaultUndefinedValue ]
+]
+
+{ #category : #'accessing-properties' }
+MADescription >> undefinedValue: anObject [
+	self propertyAt: #undefinedValue put: anObject
 ]
 
 { #category : #validation }

--- a/source/Magritte-Model/MASingleOptionDescription.class.st
+++ b/source/Magritte-Model/MASingleOptionDescription.class.st
@@ -62,7 +62,7 @@ MASingleOptionDescription >> isGrouped [
 MASingleOptionDescription >> prepareOptions: aCollection [
 	^ self isRequired
 		ifTrue: [ super prepareOptions: aCollection ]
-		ifFalse: [ (Array with: nil) , (super prepareOptions: aCollection) ]
+		ifFalse: [ (Array with: self undefinedValue) , (super prepareOptions: aCollection) ]
 ]
 
 { #category : #validating }

--- a/source/Magritte-Model/Object.extension.st
+++ b/source/Magritte-Model/Object.extension.st
@@ -149,9 +149,11 @@ Object >> mementoClass [
 
 { #category : #'*Magritte-Model' }
 Object >> readUsing: aDescription [
-	"Dispatch the read-access to the receiver using the accessor of aDescription."
+	"This hook is needed so that e.g. mementos and adaptive models can implement their own behavior. All other entry points e.g. MADescription>>#read: should come through here"
 
-	^ aDescription accessor read: self
+	| result |
+	result := aDescription accessor read: self.
+	^ result ifNil: [ aDescription undefinedValue ]
 ]
 
 { #category : #'*Magritte-Model' }

--- a/source/Magritte-Tests-Model/MAElementDescriptionTest.class.st
+++ b/source/Magritte-Tests-Model/MAElementDescriptionTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MAElementDescriptionTest,
 	#superclass : #MADescriptionTest,
-	#category : 'Magritte-Tests-Model-Description'
+	#category : #'Magritte-Tests-Model-Description'
 }
 
 { #category : #testing }
@@ -333,6 +333,15 @@ MAElementDescriptionTest >> testToStringUndefined [
 MAElementDescriptionTest >> testUndefined [
 	self description undefined: 'nop'.
 	self assert: self description undefined = 'nop'
+]
+
+{ #category : #'tests-accessing' }
+MAElementDescriptionTest >> testUndefinedValue [
+	self description undefinedValue: 'null'.
+	self assert: self description undefinedValue equals: 'null'.
+	
+	self description accessor: #yourself.
+	self assert: (self nullInstance readUsing: self description) equals: 'null'
 ]
 
 { #category : #'tests-validation' }


### PR DESCRIPTION
This allows integration with e.g. the Null Pattern. For example, let's say that my domain has a name with a single-option relation to a generational (e.g. Jr, Sr). Since generationals are optional, there is NullGenerational to avoid nil checks everywhere. Before this fix, there was no way to inject that class instead of nil. Now, there is. See the test (#testUndefinedValue).