### PR TITLE
[bug]: Validator - Update for Undefined Value (and a Test)

### DIFF
--- a/source/Magritte-Model/MAValidatorVisitor.class.st
+++ b/source/Magritte-Model/MAValidatorVisitor.class.st
@@ -34,7 +34,7 @@ MAValidatorVisitor >> use: anObject during: aBlock [
 { #category : #private }
 MAValidatorVisitor >> validate: anObject using: aDescription [
 	aDescription validateRequired: anObject.
-	anObject isNil ifTrue: [ ^ self ].
+	anObject = aDescription undefinedValue ifTrue: [ ^ self ].
 	aDescription
 		tryValidation: [ aDescription validateKind: anObject ]
 		ifPass: [ 

--- a/source/Magritte-Tests-Model/MAValidatorVisitorTest.class.st
+++ b/source/Magritte-Tests-Model/MAValidatorVisitorTest.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #MAValidatorVisitorTest,
+	#superclass : #TestCase,
+	#category : #'Magritte-Tests-Model-Visitor'
+}
+
+{ #category : #tests }
+MAValidatorVisitorTest >> testUndefinedValue [
+	self
+		shouldnt: [ 
+			MAValidatorVisitor new
+				validate: 'null'
+				using:
+					(MABooleanDescription new
+						undefinedValue: 'null';
+						yourself) ]
+		raise: MAKindError
+]


### PR DESCRIPTION
It was still using a nil guard, so custom `undefinedValue` would signal a kind error.