### PR TITLE
Simplify and Update Baseline

### DIFF
--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -45,87 +45,43 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 
 { #category : #baselines }
 BaselineOfMagritte >> baseline330ForPharo: spec [
-	spec
-		for: #'pharo1.x'
-		do: [ 
-			spec
-				project: 'FileSystem' with: [ 
-					spec
-						className: 'ConfigurationOfFilesystem';
-						versionString: #'stable';
-						loads: #( 'default' );
-						repository: 'http://www.squeaksource.com/MetacelloRepository' ].
-			spec
-				package: 'Magritte-Model' with: [ spec requires: #( 'FileSystem' ) ] ].
-	spec
-		for: #(#'pharo1.x' #'pharo2.x' #'squeak')
-		do: [ 
-			spec
-				package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo-Model') ];
-				package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo-Model') ];
-				package: 'Magritte-Pharo-Model' with: [ spec requires: #('Magritte-Model') ]].
-	spec
-		for: #(#'pharo3.x' #'pharo4.x' #'pharo5.x' #'pharo6.x')
-		do: [ 
-			spec
-				package: 'Magritte-Pharo3-Model' with: [ spec requires: #('Magritte-Model') ];
-				package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo3-Model') ];
-				package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo3-Model') ];
-				" create a temporary alias "
-				package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo3-Model'].
-	spec
-		for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x')
-		do: [ 
-			spec
-				package: 'Magritte-Pharo7-Model' with: [ spec requires: #('Magritte-Model') ];
-				package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo7-Model') ];
-				package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo7-Model') ];
-				" create a temporary alias "
-				package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo7-Model'].
-
-	spec
-		for: #(#'pharo4.x')
-		do: [ 
-			spec
-				project: 'MagritteGlamourForPharo40' with: [ 
-					spec
-						className: 'ConfigurationOfMagritteGlamourForPharo40';
-						versionString: #'stable';
-						repository: 'http://www.smalltalkhub.com/mc/SeanDeNigris/SeansMetaRepo/main' ].
-			spec package: 'Magritte-GT' with: [ spec requires: #('Morphic' 'MagritteGlamourForPharo40') ].
-			spec package: 'Magritte-Morph' with: [ spec includes: #('Magritte-GT') ].
-			spec group: 'default' with: #('Magritte-GT') ].
-	spec
-		for: #(#'pharo5.x' #'pharo6.x' #'pharo7.x' #'pharo8.x' #'pharo9.x')
-		do: [ 
-			"spec
-				baseline: 'PharoEnhancements' with: [
-					spec repository: 'github://seandenigris/Pharo-Enhancements' ]."
-			spec 
-				package: 'Magritte-Glamour' with: [ spec requires: #('Magritte-Model' 'Magritte-Morph') ];
-				package: 'Magritte-GT' with: [ spec requires: #('Morphic' 'Magritte-Glamour') ];
-				package: 'Magritte-Developer' with: [ spec requires: #('Magritte-Model') ].
-			spec group: 'default' with: #('Magritte-GT' 'Magritte-Developer') ].
-	spec
-		for: #squeakCommon
-		do: [ 
-			spec
-				package: 'Magritte-Tests-Model' with: [ spec includes: #('Magritte-Tests-Pharo-Model') ];
-				package: 'Magritte-Seaside' with: [ spec includes: #('Magritte-Pharo-Seaside') ];				
-				package: 'Magritte-Pharo-Seaside' with: [ spec requires: #('Magritte-Seaside') ];
-				package: 'Magritte-Morph' with: [ spec requires: #('Magritte-Model') ];
-				package: 'Magritte-Pharo-Tools' with: [ spec requires: #('Magritte-Deprecated') ].
-			spec
-				group: 'Tools' with: #('Magritte-Pharo-Tools');
-				group: 'Morphic' with: #('Magritte-Morph');
-				group: 'default' with: 'Morphic' ].
+	spec for: #squeakCommon do: [ 
+		spec
+			package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo-Model') ];
+			package: 'Magritte-Tests-Model' with: [ spec includes: #('Magritte-Tests-Pharo-Model') ];
+			package: 'Magritte-Pharo-Model' with: [ spec requires: #('Magritte-Model') ];
+			package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo-Model') ];
+			package: 'Magritte-Seaside' with: [ spec includes: #('Magritte-Pharo-Seaside') ];				
+			package: 'Magritte-Pharo-Seaside' with: [ spec requires: #('Magritte-Seaside') ];
+			package: 'Magritte-Morph' with: [ spec requires: #('Magritte-Model') ];
+			package: 'Magritte-Pharo-Tools' with: [ spec requires: #('Magritte-Deprecated') ].
+		spec
+			group: 'Tools' with: #('Magritte-Pharo-Tools');
+			group: 'Morphic' with: #('Magritte-Morph');
+			group: 'default' with: 'Morphic' ].
+				
+	spec for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x') do: [ 
+		spec
+			baseline: 'PharoEnhancements' with: [
+				spec repository: 'github://seandenigris/Pharo-Enhancements' ].
+		spec
+			" create a temporary alias "
+			package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo7-Model';
+			package: 'Magritte-Glamour' with: [ spec requires: #('Magritte-Model' 'Magritte-Morph') ];
+			package: 'Magritte-GT' with: [ spec requires: #('Morphic' 'Magritte-Glamour') ];
+			package: 'Magritte-Developer' with: [ spec requires: #('Magritte-Model') ].
+		spec group: 'default' with: #('Magritte-GT' 'Magritte-Developer') ].
+	
+	spec for: #(#'pharo6.x') do: [ 
+		" create a temporary alias "
+		spec package: 'Magritte-Pharo-Model' with: 'Magritte-Pharo3-Model' ].
 		
-		spec for: #GToolkit do: [ 
-			spec 
-				package: 'Magritte-UI' with: [ spec requires: #('Magritte-Model') ];
-				package: 'Magritte-GToolkit' with: [ spec requires: #('Magritte-Model' 'Magritte-UI') ];
-				package: 'Magritte-Developer' with: [ spec includes: #('Magritte-GToolkit') ].
-			spec group: 'default' with: 'Magritte-GToolkit' ]
+	spec for: #GToolkit do: [ 
+		spec 
+			package: 'Magritte-UI' with: [ spec requires: #('Magritte-Model') ];
+			package: 'Magritte-GToolkit' with: [ spec requires: #('Magritte-Model' 'Magritte-UI') ];
+			package: 'Magritte-Developer' with: [ spec includes: #('Magritte-GToolkit') ].
+		spec group: 'default' with: 'Magritte-GToolkit' ]
 ]
 
 { #category : #baselines }


### PR DESCRIPTION
Fixes (as far as Pharo) #144, but still waiting on Gemstone...

- We will only support Pharo 6+

N.B. Tried to reverse dependency between Model and Pharo-Model, but MAExternalFileModel depends on MAFileModel (superclass)