### PR TITLE
[Bug]: Reference to String

### DIFF
--- a/source/Magritte-GToolkit/MADropdownElement.class.st
+++ b/source/Magritte-GToolkit/MADropdownElement.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #BrButton,
 	#instVars : [
 		'items',
-		'selection'
+		'selection',
+		'itemDescription'
 	],
 	#category : #'Magritte-GToolkit-Widgets'
 }
@@ -75,6 +76,16 @@ MADropdownElement >> initializeToggleButton: aButton [
 ]
 
 { #category : #accessing }
+MADropdownElement >> itemDescription [
+	^ itemDescription
+]
+
+{ #category : #accessing }
+MADropdownElement >> itemDescription: anObject [
+	itemDescription := anObject
+]
+
+{ #category : #accessing }
 MADropdownElement >> items [
 	^ items ifNil: [ items := OrderedCollection new ]
 ]
@@ -111,8 +122,10 @@ MADropdownElement >> popupList [
 					do: [ :evt | self handleSelection: evt target ];
 				yourself ];
 		itemDataBinder: [ :eachElement :eachItem :eachIndex | 
+			| displayString |
 			eachElement userData at: #item put: eachItem.
-			eachElement text: eachItem displayString ];
+			displayString := self itemDescription toString: eachItem.
+			eachElement text: displayString ];
 		items: self items;
 		yourself
 ]
@@ -131,6 +144,5 @@ MADropdownElement >> selection: anObject [
 
 { #category : #accessing }
 MADropdownElement >> selectionString [
-	self flag: 'Morphic Dropdown does: `self magritteDescription reference toString: e`. Not sure what the ramifications are, but I don''t thing that uses displayString, which we need for undefinedValue/NullPattern - spd'.
-	^ self selection ifNotNil: [ :sel | sel displayString ] ifNil: ''
+	^ self itemDescription toString: self selection
 ]

--- a/source/Magritte-GToolkit/MAElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MAElementBuilder.class.st
@@ -294,6 +294,7 @@ MAElementBuilder >> visitSingleOptionDescription: aDescription [
 	| inputElement |
 	inputElement := MADropdownElement new 
 		items: aDescription allOptions;
+		itemDescription: aDescription reference;
 		selection: (self object readUsing: aDescription);
 		when: MADropdownWish do: [ :aWish | 
 			aDescription write: aWish selection to: self memento ];

--- a/source/Magritte-Model/MADescription.class.st
+++ b/source/Magritte-Model/MADescription.class.st
@@ -46,6 +46,11 @@ MADescription class >> defaultDefault [
 ]
 
 { #category : #'accessing-defaults' }
+MADescription class >> defaultDisplayProperty [
+	^ #greaseString
+]
+
+{ #category : #'accessing-defaults' }
 MADescription class >> defaultGroup [
 	^ nil
 ]
@@ -479,6 +484,32 @@ MADescription >> descriptionVisible [
 		priority: 210;
 		default: self class defaultVisible;
 		yourself
+]
+
+{ #category : #'accessing-properties' }
+MADescription >> display: aBlockOrSymbol [
+	"Transform how the file is converted to a string.
+	aSymbol
+		- is performed on the object
+		- can optionally take the description as an argument
+	aBlock
+		- takes two optional arguments: the domain object and its description
+		- returns the string to display
+	
+	NB. This string may be used to convert back to a domain object, so make sure it is suitable via the string reader in use."
+	self propertyAt: #displayBlockOrSymbol put: aBlockOrSymbol.
+]
+
+{ #category : #'accessing-properties' }
+MADescription >> displayBlockOrSymbol [
+	^ self propertyAt: #displayBlockOrSymbol ifAbsent: [ self class defaultDisplayProperty ]
+]
+
+{ #category : #displaying }
+MADescription >> displayStringFor: anObject [
+	"Convert object to a string. If a block was passed to #display: use that, otherwise use the defaultDisplayProperty. N.B. It's probably best not to use this outside of the library insternals. It should be private except that it's used by option descriptions and string writer. The canonical way to get this info is `self reference toString: anObject`"
+
+	^ self displayBlockOrSymbol cull: anObject cull: self.
 ]
 
 { #category : #strings }

--- a/source/Magritte-Model/MAElementDescription.class.st
+++ b/source/Magritte-Model/MAElementDescription.class.st
@@ -7,11 +7,6 @@ Class {
 	#category : #'Magritte-Model-Description'
 }
 
-{ #category : #'accessing-defaults' }
-MAElementDescription class >> defaultDisplayProperty [
-	^ #greaseString
-]
-
 { #category : #'instance creation' }
 MAElementDescription class >> new [
 	"override #new so that we can create an object without adding it to the collection returned by: MAElementDescription withAllConcreteClasses,
@@ -38,32 +33,6 @@ MAElementDescription >> default [
 { #category : #accessing }
 MAElementDescription >> default: anObject [
 	self propertyAt: #default put: anObject
-]
-
-{ #category : #'accessing-properties' }
-MAElementDescription >> display: aBlockOrSymbol [
-	"Transform how the file is converted to a string.
-	aSymbol
-		- is performed on the object
-		- can optionally take the description as an argument
-	aBlock
-		- takes two optional arguments: the domain object and its description
-		- returns the string to display
-	
-	NB. This string may be used to convert back to a domain object, so make sure it is suitable via the string reader in use."
-	self propertyAt: #displayBlockOrSymbol put: aBlockOrSymbol.
-]
-
-{ #category : #'accessing-properties' }
-MAElementDescription >> displayBlockOrSymbol [
-	^self propertyAt: #displayBlockOrSymbol ifAbsent: [ self class defaultDisplayProperty ]
-]
-
-{ #category : #displaying }
-MAElementDescription >> displayStringFor: anObject [
-	"Convert object to a string. If a block was passed to #display: use that, otherwise use the defaultDisplayProperty. N.B. It's probably best not to use this outside of the library insternals. It should be private except that it's used by option descriptions and string writer. The canonical way to get this info is `self reference toString: anObject`"
-
-	^ self displayBlockOrSymbol cull: anObject cull: self.
 ]
 
 { #category : #testing }

--- a/source/Magritte-Model/MAElementDescription.class.st
+++ b/source/Magritte-Model/MAElementDescription.class.st
@@ -61,7 +61,7 @@ MAElementDescription >> displayBlockOrSymbol [
 
 { #category : #displaying }
 MAElementDescription >> displayStringFor: anObject [
-	"Convert object to a string. If a block was passed to #display: use that, otherwise send #greaseString by default"
+	"Convert object to a string. If a block was passed to #display: use that, otherwise use the defaultDisplayProperty. N.B. It's probably best not to use this outside of the library insternals. It should be private except that it's used by option descriptions and string writer. The canonical way to get this info is `self reference toString: anObject`"
 
 	^ self displayBlockOrSymbol cull: anObject cull: self.
 ]

--- a/source/Magritte-Model/MAOptionDescription.class.st
+++ b/source/Magritte-Model/MAOptionDescription.class.st
@@ -28,11 +28,6 @@ Class {
 }
 
 { #category : #'accessing-defaults' }
-MAOptionDescription class >> defaultDisplayProperty [
-	^ [ :anObject :desc | desc reference toString: anObject ]
-]
-
-{ #category : #'accessing-defaults' }
 MAOptionDescription class >> defaultExtensible [
 	^ false
 ]
@@ -150,7 +145,7 @@ MAOptionDescription >> isSorted [
 
 { #category : #private }
 MAOptionDescription >> labelForOption: anObject [
-	self propertyAt: #labels ifPresent: [ :labels | labels optionFor: anObject ifPresent: [ :value | ^value ] ].
+	self propertyAt: #labels ifPresent: [ :labels | labels optionFor: anObject ifPresent: [ :value | ^ value ] ].
 	^ self displayStringFor: anObject.
 ]
 

--- a/source/Magritte-Model/MAReferenceDescription.class.st
+++ b/source/Magritte-Model/MAReferenceDescription.class.st
@@ -1,7 +1,24 @@
 "
 I am an abstract superclass for descriptions holding onto another description.
 !What is a ==reference==?
-My subclasses describe the ''relationship'' between the containing object and the referenced objects (e.g. tree -> apples), but what if we need a decription of a referenced object ''itself''? This is where my ==reference== comes in.
+My subclasses describe the ''relationship'' between the containing object and the referenced objects (e.g. tree -> apples), but what if we need a decription of a referenced object ''itself''? In some cases, the object might already have a description we can use. If not, this is where my ==reference== comes in. 
+!!Use Cases
+Here are two common use cases:
+!!!Fine-grained control
+The comment of ${method:MARelationDescription>>#reference}$ has this tantalizing hint to get you started: ==By setting the reference to a MAContainer instance it is possible to customize the reference description==. Magritte does not seem to offer any examples of how that would actually work, but luckily Lukas provided one [1]:
+> you want a different string to be displayed? If so, try this 
+==
+	reference: (MAContainer with: (MAStringDescription new   
+		selectorAccessor: #printString; yourself)) 
+==
+>and implement your own printOn: method in your referenced object as   
+you wish. 
+!!!No Object Description
+The object doesn't ''have'' a description (although in this case, you could add a description via extension methods). Maybe it is an object from outside your project. In this case when no ==reference== description is provided, Magritte tries to create an appropriate one. See for yourself:
+
+[[[language=smalltalk
+	#reference gtImplementors & 'Magritte' gtPackageMatches
+]]]
 !!Motivation
 Why would we need such a description, you ask? Perhaps you want to convert these objects to strings for display in a GUI (e.g. ${method:MAOptionDescription>>#labelForOption:}$), or validate a user-added option (e.g. ${method:MAOptionDescription>>#validateOptionKind:}$). To get a feel for how references are used in practice, you may want to take a few moments to browse the clients:
 
@@ -9,13 +26,6 @@ Why would we need such a description, you ask? Perhaps you want to convert these
 	#reference gtReferences & 'Magritte' gtPackageMatches
 ]]]
 
-The next question that comes to mind might be, ""why can't we just use the object's own description?"" That's a great question. Here are some reasons why that may not work:
-- You want fine-grained control. The comment of ${method:MARelationDescription>>#reference}$ has this tantalizing hint to get you started: ==By setting the reference to a MAContainer instance it is possible to customize the reference description==. That said, Magritte does not seem to offer any examples of how that would actually work.
-- The object doesn't ''have'' a description (although in this case, you could add a description via extension methods). Maybe it is an object from outside your project. In this case when no ==reference== description is provided, Magritte tries to create an appropriate one. See for yourself:
-
-[[[language=smalltalk
-	#reference gtImplementors & 'Magritte' gtPackageMatches
-]]]
 !!Further Research
 If this isn't clear enough, here are some other 
 Here's a description from the ""Magritte - Web Development"" paper:
@@ -36,15 +46,8 @@ a specialized one. When navigating from an order to an orderLine,
 we might not want to use the orderDescription of the orderLine. - *Stephan Eggermont>http://forum.world.st/reference-what-is-it-tp4805794p4813841.html*
 
 From *a 2006 thread>http://forum.world.st/MA-labaled-options-tp116188.html`*, seems to confirm that a reference is a Magritte description that describes the referenced objects.
-
-*Here>http://forum.world.st/MAToOneRelationDescription-dispaly-data-tp117214p117218.html*, Lukas says:
-> you want a different string to be displayed? If so, try this 
-==
-	reference: (MAContainer with: (MAStringDescription new   
-		selectorAccessor: #printString; yourself)) 
-==
->and implement your own printOn: method in your referenced object as   
-you wish. 
+!References
+1. *Lukas on customizing references via the Magritte ML>http://forum.world.st/MAToOneRelationDescription-dispaly-data-tp117214p117218.html*
 "
 Class {
 	#name : #MAReferenceDescription,
@@ -95,7 +98,10 @@ MAReferenceDescription >> postCopy [
 
 { #category : #accessing }
 MAReferenceDescription >> reference [
-	^ reference ifNil: [ reference := self class defaultReference ]
+	reference ifNil: [ reference := self class defaultReference ].
+	^ reference
+		display: self displayBlockOrSymbol;
+		yourself
 ]
 
 { #category : #accessing }

--- a/source/Magritte-Morph/MAElementRow.class.st
+++ b/source/Magritte-Morph/MAElementRow.class.st
@@ -86,7 +86,7 @@ MAElementRow >> initialize [
 		cellInset: self cellInset;
 		layoutInset: 0@2.
 	self
-		addMorphBack: (container magritteDescription displayStringFor: object) asMorph;
+		addMorphBack: (container magritteDescription toString: object) asMorph;
 		addMorphBack: self buildCommands
 ]
 

--- a/source/Magritte-Morph/MAMorphicDate.class.st
+++ b/source/Magritte-Morph/MAMorphicDate.class.st
@@ -8,7 +8,7 @@ Class {
 MAMorphicDate >> buildMorphView [
 	| model |
 	model := DateModel new
-		displayBlock: [ :e | self magritteDescription displayStringFor: e ];
+		displayBlock: [ :e | self magritteDescription toString: e ];
 		date: self value;
 		whenDateChanged: [ :newDate | self value: newDate ];
 		yourself.

--- a/source/Magritte-Morph/MAMorphicFile.class.st
+++ b/source/Magritte-Morph/MAMorphicFile.class.st
@@ -57,6 +57,6 @@ MAMorphicFile >> currentValueMorph [
 MAMorphicFile >> displayCurrentValue [
 
 	| displayString |
-	displayString := self magritteDescription displayStringFor: self value.
+	displayString := self magritteDescription toString: self value.
 	self currentValueMorph contents: displayString.
 ]


### PR DESCRIPTION
Still in the process of fully integrating element #display: with references. There were a lot of places using #displayStringFor: directly, which is used internally by the string reader/writer and should probably best be used that way to avoid sprinkling implementation details all over the place.