### PR TITLE
[Enh]: Descriptions - Real Names

### DIFF
--- a/source/Magritte-Model/MADescription.class.st
+++ b/source/Magritte-Model/MADescription.class.st
@@ -373,11 +373,9 @@ MADescription >> descriptionLabel [
 { #category : #'acessing-magritte' }
 MADescription >> descriptionName [
 	<magritteDescription>
-	^ MAStringDescription new
+	^ MASymbolDescription new
 		accessor: #name;
-		label: 'Kind';
-		priority: 0;
-		beReadOnly;
+		priority: 1;
 		yourself
 ]
 
@@ -438,6 +436,17 @@ MADescription >> descriptionStringWriter [
 		default: self class defaultStringWriter;
 		options: self class defaultStringWriter withAllSubclasses;
 		reference: MAClassDescription new;
+		yourself
+]
+
+{ #category : #'acessing-magritte' }
+MADescription >> descriptionType [
+	<magritteDescription>
+	^ MAStringDescription new
+		accessor: #type;
+		label: 'Kind';
+		priority: 0;
+		beReadOnly;
 		yourself
 ]
 
@@ -682,9 +691,12 @@ MADescription >> multipleErrorsMessage: aString [
 
 { #category : #'accessing-configuration' }
 MADescription >> name [
-	"Answer the name of the description, a human-readable string describing the type."
+	^ self propertyAt: #name ifAbsent: [ self accessor name ]
+]
 
-	^ self class label
+{ #category : #'accessing-configuration' }
+MADescription >> name: aSymbol [
+	^ self propertyAt: #name put: aSymbol
 ]
 
 { #category : #copying }
@@ -843,6 +855,13 @@ MADescription >> tryValidation: tryBlock ifPass: passBlock [
 	tryBlock on: MAValidationError do: [ :e | shouldContinue := false. e pass ].
 	shouldContinue ifFalse: [ ^ self ].
 	passBlock value
+]
+
+{ #category : #'accessing-configuration' }
+MADescription >> type [
+	"Answer the name of the description, a human-readable string describing the type."
+
+	^ self class label
 ]
 
 { #category : #'accessing-strings' }

--- a/source/Magritte-Model/MADirectoryDescription.class.st
+++ b/source/Magritte-Model/MADirectoryDescription.class.st
@@ -1,12 +1,12 @@
 Class {
 	#name : #MADirectoryDescription,
 	#superclass : #MAFileDescription,
-	#category : 'Magritte-Model-Description'
+	#category : #'Magritte-Model-Description'
 }
 
 { #category : #acessing }
 MADirectoryDescription class >> label [
-	^'Directory'
+	^ 'Directory'
 ]
 
 { #category : #visiting }

--- a/source/Magritte-Model/MASelectorAccessor.class.st
+++ b/source/Magritte-Model/MASelectorAccessor.class.st
@@ -76,6 +76,11 @@ MASelectorAccessor >> hash [
 	^  super hash bitXor: (self readSelector hash bitXor: self writeSelector hash)
 ]
 
+{ #category : #'acessing-magritte' }
+MASelectorAccessor >> name [
+	^ self readSelector
+]
+
 { #category : #model }
 MASelectorAccessor >> read: aModel [
 	^ aModel perform: self readSelector


### PR DESCRIPTION
It can often be useful for a description to have a canonical name. For some accessors there is an obvious default e.g. read selector or variable name.

Descriptions *did* have a "name", but it was really a string explaining the type of the description itself e.g. "1:M..." for to-many descriptions. 

Here, we rename the existing `#name` behavior to `#type` and reimplement `#name` as a configurable canonical specifier.