### PR TITLE
[Bug]: All Accessors Should Implement `#name`

### DIFF
--- a/source/Magritte-Model/MAAccessor.class.st
+++ b/source/Magritte-Model/MAAccessor.class.st
@@ -37,6 +37,11 @@ MAAccessor >> handlesSelector: aSelector [
 
 ]
 
+{ #category : #accessing }
+MAAccessor >> name [
+	^ nil
+]
+
 { #category : #printing }
 MAAccessor >> printOn: aStream [
 	self storeOn: aStream

--- a/source/Magritte-Model/MAChainAccessor.class.st
+++ b/source/Magritte-Model/MAChainAccessor.class.st
@@ -67,6 +67,11 @@ MAChainAccessor >> hash [
 	^ super hash bitXor: self accessor hash
 ]
 
+{ #category : #model }
+MAChainAccessor >> name [
+	^ super name, '::', self accessor name
+]
+
 { #category : #copying }
 MAChainAccessor >> postCopy [
 	super postCopy.

--- a/source/Magritte-Model/MADelegatorAccessor.class.st
+++ b/source/Magritte-Model/MADelegatorAccessor.class.st
@@ -52,6 +52,11 @@ MADelegatorAccessor >> hash [
 ]
 
 { #category : #accessing }
+MADelegatorAccessor >> name [
+	^ self next name
+]
+
+{ #category : #accessing }
 MADelegatorAccessor >> next [
 	^ next
 ]

--- a/source/Magritte-Model/MADictionaryAccessor.class.st
+++ b/source/Magritte-Model/MADictionaryAccessor.class.st
@@ -67,6 +67,11 @@ MADictionaryAccessor >> keyDescription [
 		yourself
 ]
 
+{ #category : #accessing }
+MADictionaryAccessor >> name [
+	^ self key
+]
+
 { #category : #model }
 MADictionaryAccessor >> read: aModel [
 	^ aModel at: self key ifAbsent: [ nil ]

--- a/source/Magritte-Model/MASelectorAccessor.class.st
+++ b/source/Magritte-Model/MASelectorAccessor.class.st
@@ -76,7 +76,7 @@ MASelectorAccessor >> hash [
 	^  super hash bitXor: (self readSelector hash bitXor: self writeSelector hash)
 ]
 
-{ #category : #'acessing-magritte' }
+{ #category : #accessing }
 MASelectorAccessor >> name [
 	^ self readSelector
 ]


### PR DESCRIPTION
Some weren't, leading to a DNU when looking up field names e.g. when inspecting a description