### PR TITLE
[Bug]: Chain Accessors Fields Flipped

### DIFF
--- a/source/Magritte-Model/MAChainAccessor.class.st
+++ b/source/Magritte-Model/MAChainAccessor.class.st
@@ -17,8 +17,8 @@ MAChainAccessor class >> accessors: aSequenceableCollection [
 	aSequenceableCollection size = 1
 		ifTrue: [ ^ aSequenceableCollection first asAccessor ].
 	^ self 
-		on: aSequenceableCollection first asAccessor 
-		accessor: (self accessors: aSequenceableCollection allButFirst)
+		on: (self accessors: aSequenceableCollection allButFirst)
+		accessor: aSequenceableCollection first asAccessor
 ]
 
 { #category : #'instance creation' }
@@ -43,12 +43,12 @@ MAChainAccessor >> accessor: anAccessor [
 
 { #category : #testing }
 MAChainAccessor >> canRead: aModel [
-	^ (super canRead: aModel) and: [ self accessor canRead: (self next read: aModel) ]
+	^ (self accessor canRead: aModel) and: [ self next canRead: (self accessor read: aModel) ]
 ]
 
 { #category : #testing }
 MAChainAccessor >> canWrite: aModel [
-	^ (super canRead: aModel) and: [ self accessor canWrite: (self next read: aModel) ]
+	^ (self accessor canRead: aModel) and: [ self next canWrite: (self accessor read: aModel) ]
 ]
 
 { #category : #'accessing-magritte' }
@@ -80,7 +80,7 @@ MAChainAccessor >> postCopy [
 
 { #category : #model }
 MAChainAccessor >> read: aModel [
-	^ self accessor read: (super read: aModel)
+	^ super read: (self accessor read: aModel)
 ]
 
 { #category : #printing }
@@ -97,5 +97,5 @@ MAChainAccessor >> storeOn: aStream [
 
 { #category : #model }
 MAChainAccessor >> write: anObject to: aModel [
-	self accessor write: anObject to: (super read: aModel)
+	super write: anObject to: (self accessor read: aModel)
 ]

--- a/source/Magritte-Tests-Model/MAChainAccessorTest.class.st
+++ b/source/Magritte-Tests-Model/MAChainAccessorTest.class.st
@@ -41,32 +41,32 @@ MAChainAccessorTest >> testAsAccessor [
 	accessor := #(value contents) asAccessor.
 	self assert: (accessor isKindOf: MAChainAccessor).
 	self assert: (accessor next isKindOf: MASelectorAccessor).
-	self assert: (accessor next selector = #value).
+	self assert: (accessor next selector = #contents).
 	self assert: (accessor accessor isKindOf: MASelectorAccessor).
-	self assert: (accessor accessor selector = #contents)
+	self assert: (accessor accessor selector = #value)
 ]
 
 { #category : #'tests-testing' }
 MAChainAccessorTest >> testCanRead [
 	self assert: (self accessor canRead: self).
-	self accessor accessor accessor readSelector: #zork.
+	self accessor next accessor readSelector: #zork.
 	self deny: (self accessor canRead: self)
 ]
 
 { #category : #'tests-testing' }
 MAChainAccessorTest >> testCanWrite [
 	self assert: (self accessor canWrite: self).
-	self accessor accessor accessor writeSelector: #zork.
-	self deny: (self accessor canWrite: self)
+	self accessor next accessor writeSelector: #zork.
+	self deny: (self accessor accessor canWrite: self)
 ]
 
 { #category : #tests }
 MAChainAccessorTest >> testKind [
-	self assert: (self accessor class = MAChainAccessor).
-	self assert: (self accessor next class = MASelectorAccessor).
-	self assert: (self accessor accessor class = MAChainAccessor).
-	self assert: (self accessor accessor next class = MASelectorAccessor).
-	self assert: (self accessor accessor accessor class = MASelectorAccessor)
+	self assert: self accessor class equals: MAChainAccessor.
+	self assert: self accessor accessor class equals: MASelectorAccessor.
+	self assert: self accessor next class equals: MAChainAccessor.
+	self assert: self accessor next accessor class equals: MASelectorAccessor.
+	self assert: self accessor next next class equals: MASelectorAccessor
 ]
 
 { #category : #tests }
@@ -88,9 +88,9 @@ MAChainAccessorTest >> testRead [
 
 { #category : #tests }
 MAChainAccessorTest >> testSelector [
-	self assert: self accessor next selector = #holder.
-	self assert: self accessor accessor next selector = #contents.
-	self assert: self accessor accessor accessor selector = #value
+	self assert: self accessor accessor selector equals: #holder.
+	self assert: self accessor next accessor selector equals: #contents.
+	self assert: self accessor next next selector equals: #value
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Per the class comment: "To read and write a value the ==accessor== is performed on the given model and the result is passed into the ==next== accessor."
However, the implementation was using the ==next== accessor *first* instead of last.

Having trouble committing the fixes to the tests so there will likely be at least one more commit for this.