### PR TITLE
Fix #221: Composite Form Element

### DIFF
--- a/source/Magritte-GToolkit/MACompositeElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MACompositeElementBuilder.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : #MACompositeElementBuilder,
+	#superclass : #MAElementBuilder,
+	#category : #'Magritte-GToolkit'
+}
+
+{ #category : #accessing }
+MACompositeElementBuilder class >> example [
+	<gtExample>
+	^ self new
+		object: { #people -> { 
+			self samplePersonHarryPotter.
+			self samplePersonDumbledore } } asDictionary;
+		objectDescription: self sampleDescription;
+		addButtons;
+		element
+]
+
+{ #category : #'example support' }
+MACompositeElementBuilder class >> sampleDescription [
+	| desc |
+	desc := super sampleDescription
+		blocClass: MACompositeElementBuilder;
+		yourself.
+	desc children do: [ :e | 
+		| acc prefixAccessor |
+		prefixAccessor := MADictionaryAccessor key: #people.
+		acc := MACompositeAccessor via: prefixAccessor using: e ].
+	^ desc
+]
+
+{ #category : #'example support' }
+MACompositeElementBuilder class >> samplePersonDumbledor [
+	^ {
+			#name ->'Albus Percival Wulfric Brian Dumbledore'.
+			#birthplace -> 'Godric''s Hollow' } asDictionary
+]
+
+{ #category : #'example support' }
+MACompositeElementBuilder class >> samplePersonDumbledore [
+	^ {
+			#name ->'Albus Percival Wulfric Brian Dumbledore'.
+			#birthplace -> 'Godric''s Hollow' } asDictionary
+]
+
+{ #category : #accessing }
+MACompositeElementBuilder >> visitSingleOptionDescription: aDescription [
+	| inputElement items |
+	self flag: 'lots of duplication with super implementation'.
+	items := aDescription allOptions copyWith: MACompositeConflict new; yourself.
+	inputElement := MADropdownElement new 
+		items: items;
+		itemDescription: aDescription reference;
+		selection: (aDescription read: self memento);
+		when: MADropdownWish do: [ :aWish | 
+			aWish selection = MACompositeConflict new ifFalse: [ aDescription write: aWish selection to: self memento ] ];
+		yourself.
+	self addInputField: inputElement using: aDescription
+]

--- a/source/Magritte-GToolkit/MADescription.extension.st
+++ b/source/Magritte-GToolkit/MADescription.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #MADescription }
+
+{ #category : #'*Magritte-GToolkit' }
+MADescription >> blocClass [
+	^ self propertyAt: #blocClass ifAbsent: [ MAElementBuilder"self class defaultMorphicClass" ]
+]
+
+{ #category : #'*Magritte-GToolkit' }
+MADescription >> blocClass: aClass [
+	^ self propertyAt: #blocClass put: aClass
+]

--- a/source/Magritte-GToolkit/MADropdownElement.class.st
+++ b/source/Magritte-GToolkit/MADropdownElement.class.st
@@ -146,3 +146,9 @@ MADropdownElement >> selection: anObject [
 MADropdownElement >> selectionString [
 	^ self itemDescription toString: self selection
 ]
+
+{ #category : #accessing }
+MADropdownElement >> text [
+	"This is to show the initial value in the container UI"
+	^ self selectionString
+]

--- a/source/Magritte-GToolkit/MAElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MAElementBuilder.class.st
@@ -1,3 +1,10 @@
+"
+I create a Bloc element representing a Magritte form. By default, I use my model ${method:MAElementBuilder>>#object}$'s Magritte Description, but you can pass any to ${method:MAElementBuilder>>#visit:}$.
+!Implementation Note
+Unlike the Morphic implementation, which has a presenter class per description type, I take advantage of Magritte's built-in visitor capabilities. This allowed us to avoid about 18 classes, many of which had only a few methods. We will see if this approach holds up as the implementation is fleshed out and used in the real world. We ''did'' implement ${class:MABlocContainerPresenter}$ because it represents the model object and:
+- provides a nice point for inspection/debugging. To access from my built element: ==anElement userData at: #magrittePresenter==
+- serves as the reciever for form actions like ${method:MABlocContainerPresenter>>#save|label='save'}$.
+"
 Class {
 	#name : #MAElementBuilder,
 	#superclass : #MAVisitor,
@@ -6,7 +13,8 @@ Class {
 		'element',
 		'form',
 		'presenter',
-		'buttonSelectors'
+		'buttonSelectors',
+		'objectDescription'
 	],
 	#category : #'Magritte-GToolkit'
 }
@@ -18,6 +26,33 @@ MAElementBuilder class >> buildElementFor: anObject [
 		visit: anObject magritteDescription
 ]
 
+{ #category : #accessing }
+MAElementBuilder class >> example [
+	<gtExample>
+	^ self new
+		object: self samplePersonHarryPotter;
+		objectDescription: self sampleDescription
+]
+
+{ #category : #accessing }
+MAElementBuilder class >> sampleDescription [
+	^ MAPriorityContainer
+		withAll:
+			{(MAStringDescription new
+				accessor: (MADictionaryAccessor key: #name);
+				yourself).
+			(MAStringDescription new
+				accessor: (MADictionaryAccessor key: #birthplace);
+				yourself)}
+]
+
+{ #category : #accessing }
+MAElementBuilder class >> samplePersonHarryPotter [
+	^ {
+			#name ->'Harry Potter'.
+			#birthplace -> 'Godric''s Hollow' } asDictionary
+]
+
 { #category : #generic }
 MAElementBuilder >> addButtons [
 	self addButtons: #( save cancel )
@@ -25,28 +60,31 @@ MAElementBuilder >> addButtons [
 
 { #category : #accessing }
 MAElementBuilder >> addButtons: aCollection [
-	"#addButtons: is part of the existing Morphic/Seaside API. We store the selectors instead of constructing the buttons to defer all element creation to first element access"
+	"#addButtons: is part of the existing Morphic/Seaside API"
+	self flag: 'The comment said "We store the selectors instead of constructing the buttons to defer all element creation to first element access", but does that really make sense because the form and toolbar are created on visit?'.
 	self buttonSelectors: aCollection
 ]
 
 { #category : #accessing }
 MAElementBuilder >> addInputField: inputElement using: aDescription [
-	| labelElement |
+	| labelElement diffElement |
 	labelElement := BrLabel new
 		text: aDescription label , ':';
-		aptitude: BrGlamorousLabelLook.
-	labelElement
-		constraintsDo: [ :c | 
+		aptitude: BrGlamorousLabelAptitude.
+	labelElement constraintsDo: [ :c | 
 			c vertical fitContent.
 			c horizontal fitContent.
 			c grid vertical alignCenter ].
-	aDescription isRequired
-		ifTrue: [ self flag: 'unsupported' ].
-	aDescription hasComment
-		ifTrue: [ self addTooltip: aDescription comment to: labelElement.
-			self addTooltip: aDescription comment to: inputElement ].
+	aDescription isRequired ifTrue: [ self flag: 'unsupported' ].
+	aDescription hasComment ifTrue: [ 
+		self addTooltip: aDescription comment to: labelElement.
+		self addTooltip: aDescription comment to: inputElement ].
+	diffElement := BrEditor new
+		text: inputElement text copy; "if we don't copy, diff magically changes as input updates"
+		aptitude: BrGlamorousEditorAptitude.
 	self form addChild: labelElement.
-	self form addChild: inputElement
+	self form addChild: inputElement.
+	self form addChild: diffElement.
 ]
 
 { #category : #accessing }
@@ -59,8 +97,7 @@ MAElementBuilder >> addInputFieldUsing: aDescription [
 			c horizontal matchParent.
 			c grid vertical alignCenter ];
 		when: BrEditorAcceptWish
-			do:
-				[ :aWish | aDescription writeFromString: aWish text greaseString to: self memento ];
+			do: [ :aWish | aDescription writeFromString: aWish text greaseString to: self memento ];
 		text: (self textUsing: aDescription).
 	self addInputField: inputElement using: aDescription
 ]
@@ -73,7 +110,7 @@ MAElementBuilder >> addTooltip: aString to: anElement [
 			'Didn''t do `BrGlamorousWithTooltipLook content:` due to bug reported on GT discord feedback channel 12/21/2020'.
 	look := BrGlamorousWithTooltipAptitude new
 		contentStencil: [ BrLabel new
-				look: BrGlamorousLabelAptitude new glamorousRegularFontAndSize;
+				aptitude: BrGlamorousLabelAptitude new glamorousRegularFontAndSize;
 				padding: (BlInsets all: 2);
 				text: aString;
 				alignCenter ].
@@ -92,7 +129,10 @@ MAElementBuilder >> buttonSelectors: aCollection [
 
 { #category : #accessing }
 MAElementBuilder >> element [
+	| hasVisited |
 	element ifNotNil: [ ^ element ].
+	hasVisited := form isNotNil.
+	hasVisited ifFalse: [ self visit: self objectDescription ].
 	element := BrVerticalPane new
 		vFitContent;
 		hMatchParent;
@@ -105,12 +145,21 @@ MAElementBuilder >> element [
 
 { #category : #accessing }
 MAElementBuilder >> form [
+	| headerStancil |
 	form ifNotNil: [ ^ form ].
+	headerStancil := [ :string | 
+		BrLabel new 
+			text: string asRopedText bold;
+			aptitude: BrGlamorousLabelAptitude;
+			yourself ].
 	^ form := BlElement new
 		constraintsDo: [ :c |  
 			c vertical fitContent.
 			c horizontal matchParent ];
-		layout: (BlGridLayout horizontal columnCount: 2; cellSpacing: 10);
+		layout: (BlGridLayout horizontal columnCount: 3; cellSpacing: 10);
+		addChild: (headerStancil value: 'Field');
+		addChild: (headerStancil value: 'Current');
+		addChild: (headerStancil value: 'Original');
  		yourself.
 ]
 
@@ -135,13 +184,23 @@ MAElementBuilder >> object: anObject [
 ]
 
 { #category : #accessing }
+MAElementBuilder >> objectDescription [
+	^ objectDescription ifNil: [ objectDescription := self object magritteDescription ]
+]
+
+{ #category : #accessing }
+MAElementBuilder >> objectDescription: aDescription [
+	objectDescription := aDescription
+]
+
+{ #category : #accessing }
 MAElementBuilder >> presenter [
 	| memento |
 	presenter ifNotNil: [ ^ presenter ].
 	"Morphic puts this in container"
 	memento := self object mementoClass
 		model: self object
-		description: self object magritteDescription.
+		description: self objectDescription.
 	^ presenter := MABlocContainerPresenter memento: memento
 ]
 
@@ -295,7 +354,7 @@ MAElementBuilder >> visitSingleOptionDescription: aDescription [
 	inputElement := MADropdownElement new 
 		items: aDescription allOptions;
 		itemDescription: aDescription reference;
-		selection: (self object readUsing: aDescription);
+		selection: (self memento readUsing: aDescription);
 		when: MADropdownWish do: [ :aWish | 
 			aDescription write: aWish selection to: self memento ];
 		yourself.

--- a/source/Magritte-GToolkit/Object.extension.st
+++ b/source/Magritte-GToolkit/Object.extension.st
@@ -31,16 +31,21 @@ Object >> gtActions [
 { #category : #'*Magritte-GToolkit' }
 Object >> maGtFormFor: aView [
 	<gtView>
-	(self magritteDescription isContainer not or: [ self magritteDescription isEmpty ]) ifTrue: [ ^ aView empty ].
+	| description |
+	
+	"Cache the description because this can be expensive and we want the view to be fast not to break the debugging workflow"
+	description := self magritteDescription.
+	
+	(description isContainer not or: [ description isEmpty ]) ifTrue: [ ^ aView empty ].
 	^ aView explicit
 		title: 'Magritte';
 		priority: 50;
-		stencil: [ self magritteElementBuilder addButtons; element ]
+		stencil: [ (description elementBuilderFor: self) addButtons; element ]
 ]
 
 { #category : #'*Magritte-GToolkit' }
 Object >> magritteElementBuilder [
-	^ MAElementBuilder buildElementFor: self
+	^ self magritteDescription elementBuilderFor: self
 ]
 
 { #category : #'*Magritte-GToolkit' }

--- a/source/Magritte-Model/MAChainAccessor.class.st
+++ b/source/Magritte-Model/MAChainAccessor.class.st
@@ -51,6 +51,11 @@ MAChainAccessor >> canWrite: aModel [
 	^ (self accessor canRead: aModel) and: [ self next canWrite: (self accessor read: aModel) ]
 ]
 
+{ #category : #accessing }
+MAChainAccessor >> defaultLabelFor: aDescription [
+	^ (self accessor defaultLabelFor: aDescription), '::', (super defaultLabelFor: aDescription)
+]
+
 { #category : #'accessing-magritte' }
 MAChainAccessor >> descriptionAccessor [
 	<magritteDescription>

--- a/source/Magritte-Model/MACheckedMemento.class.st
+++ b/source/Magritte-Model/MACheckedMemento.class.st
@@ -1,5 +1,5 @@
 "
-I cache values as my superclass and also remember the original values of the model at the time the cache is built. With this information I am able to detect edit conflicts and can prevent accidental loss of data by merging the changes.
+Besides caching values like my superclass, I also remember the original values of the model at the time the cache is built. With this information I am able to detect edit conflicts and can prevent accidental loss of data by merging the changes.
 "
 Class {
 	#name : #MACheckedMemento,
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'original'
 	],
-	#category : 'Magritte-Model-Memento'
+	#category : #'Magritte-Model-Memento'
 }
 
 { #category : #testing }

--- a/source/Magritte-Model/MACompositeAccessor.class.st
+++ b/source/Magritte-Model/MACompositeAccessor.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : #MACompositeAccessor,
+	#superclass : #MAChainAccessor,
+	#instVars : [
+		'kind'
+	],
+	#classInstVars : [
+		'elementKind'
+	],
+	#category : #'Magritte-Model-Accessor'
+}
+
+{ #category : #'instance creation' }
+MACompositeAccessor class >> via: anAccessor using: aDescription [
+	| result |
+	result := (self on: aDescription accessor asAccessor accessor: anAccessor asAccessor)
+		kind: aDescription kind;
+		yourself.
+	aDescription hasLabel ifTrue: [ aDescription label: (result accessor defaultLabelFor: aDescription) , '::' , aDescription label ].
+	aDescription accessor: result.
+	^ result
+]
+
+{ #category : #testing }
+MACompositeAccessor >> canRead: aModel [
+	^ (self accessor canRead: aModel) and: [ (self elementsFrom: aModel) allSatisfy: [ :e | self next canRead: e ] ]
+]
+
+{ #category : #testing }
+MACompositeAccessor >> canWrite: aModel [
+	^ (self accessor canRead: aModel) and: [ (self elementsFrom: aModel) allSatisfy: [ :e | self next canWrite: e ] ]
+]
+
+{ #category : #testing }
+MACompositeAccessor >> elementsFrom: aModel [
+	^ self accessor read: aModel
+]
+
+{ #category : #accessing }
+MACompositeAccessor >> kind [
+	^ kind
+]
+
+{ #category : #accessing }
+MACompositeAccessor >> kind: aClass [
+	kind := aClass
+]
+
+{ #category : #model }
+MACompositeAccessor >> read: aModel [
+	| elements values |
+	elements := self elementsFrom: aModel.
+	values := elements collect: [ :e | self next read: e ].
+	^ values asSet size > 1
+		ifTrue: [ MACompositeConflict new kind: self kind; yourself  ]
+		ifFalse: [ values first ].
+	
+]
+
+{ #category : #model }
+MACompositeAccessor >> write: anObject to: aModel [
+	^ (self elementsFrom: aModel) do: [ :e | 
+		(anObject isKindOf: MACompositeConflict) ifFalse: [ self next write: anObject to: e ] ]
+]

--- a/source/Magritte-Model/MACompositeConflict.class.st
+++ b/source/Magritte-Model/MACompositeConflict.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #MACompositeConflict,
+	#superclass : #Object,
+	#instVars : [
+		'kind',
+		'string'
+	],
+	#category : #'Magritte-Model'
+}
+
+{ #category : #comparing }
+MACompositeConflict >> = rhs [
+	^ self species = rhs species
+]
+
+{ #category : #accessing }
+MACompositeConflict >> doesNotUnderstand: aMessage [
+	^ (self kind canUnderstand: aMessage selector)
+		ifTrue: [ self string ]
+		ifFalse: [ super doesNotUnderstand: aMessage ]
+]
+
+{ #category : #comparing }
+MACompositeConflict >> hash [
+	^ self species hash
+]
+
+{ #category : #'class membership' }
+MACompositeConflict >> isKindOf: aClass [
+	"This is to pass #validateKind:"
+	^ (super isKindOf: aClass) or: [ self kind = aClass ]
+]
+
+{ #category : #accessing }
+MACompositeConflict >> kind [
+	^ kind
+]
+
+{ #category : #accessing }
+MACompositeConflict >> kind: aClass [
+	kind := aClass
+]
+
+{ #category : #printing }
+MACompositeConflict >> printOn: aStream [
+	aStream nextPutAll: self string
+]
+
+{ #category : #accessing }
+MACompositeConflict >> string [
+	^ string ifNil: [ '(Multiple values)' ]
+]
+
+{ #category : #accessing }
+MACompositeConflict >> string: aString [
+	string := aString
+]

--- a/source/Magritte-Model/MADelegatorAccessor.class.st
+++ b/source/Magritte-Model/MADelegatorAccessor.class.st
@@ -35,6 +35,11 @@ MADelegatorAccessor >> canWrite: aModel [
 	^ self next canWrite: aModel
 ]
 
+{ #category : #accessing }
+MADelegatorAccessor >> defaultLabelFor: aDescription [
+	^ self next defaultLabelFor: aDescription
+]
+
 { #category : #'accessing-magritte' }
 MADelegatorAccessor >> descriptionNext [
 	<magritteDescription>

--- a/source/Magritte-Model/MAMemento.class.st
+++ b/source/Magritte-Model/MAMemento.class.st
@@ -1,5 +1,9 @@
 "
-I am an abstract memento. I reference the model I am working on and the description currently used to describe this model.
+!Responsibilities
+I am an abstract memento. I am a stand-in for an object, typically for reading and writing. Subclasses ''may'' save the pre-operation state (e.g. ${class:MACachedMemento}$), or ''may not'' (e.g. ${class:MAStraightMemento}$. Similarly, they ''may'' verify described conditions are met (e.g. ${class:MACheckedMemento}$). NB. My behavior is different than a GoF ==Memento==, which is immutable, saving an object's state before it's modified by an operation.
+!Collaborators
+- the ==model== I represent/modify
+- the ==description== currently used to describe this ==model==
 "
 Class {
 	#name : #MAMemento,
@@ -50,6 +54,7 @@ MAMemento >> isDifferent: firstDictionary to: secondDictionary [
 
 { #category : #accessing }
 MAMemento >> magritteDescription [
+	"`#modelDescription` would probably be clearer, but we want to be polymorphic (see implementors)"
 	^ description
 ]
 

--- a/source/Magritte-Morph/MAContainer.extension.st
+++ b/source/Magritte-Morph/MAContainer.extension.st
@@ -13,3 +13,13 @@ MAContainer >> asMorphOn: anObject [
 MAContainer class >> defaultMorphicClasses [
 	^ Array with: MAMorphicContainer
 ]
+
+{ #category : #'*magritte-morph-converting' }
+MAContainer >> elementBuilderFor: anObject [
+	
+	self flag: 'Commented out from #asMorphOn:'.
+	"memento := anObject mementoClass
+			model: anObject
+			description: self."
+	^ self blocClass buildElementFor: anObject"memento: memento"
+]


### PR DESCRIPTION
This might be more trouble than it's worth, but it "works" and is a test of the extensibility of the visitor builder(s), so we'll keep it until we have something better.

- Composite Element Builder and example(s)
- `MADescription>>#blocClass`, just like `#morphicClass`
- Make dropdown element polymorphic with Editor Element RE initial string
- Element Builder
  - Add Diff Column
  - [Port]: Update some look -> aptitude stuff
  - Form column headers
  - Cache description; not sure if really needed since gets passed to `#visit:`, but makes it convenient that we don't need to pass it everywhere e.g. `presenterUsing: aDescription`
  - Examples
- Object `#magritteElementBuilder` - honor container's prefered class
- Chain Accessor - default label
- [Feature]: Composite Accessor/Conflict
- [Doc]: Class and method comments (some unrelated to issue)