### PR TITLE
Patches - Flesh out GT Support

### DIFF
--- a/source/Magritte-Merging/MAPatchMacro.class.st
+++ b/source/Magritte-Merging/MAPatchMacro.class.st
@@ -2,11 +2,41 @@ Class {
 	#name : #MAPatchMacro,
 	#superclass : #Object,
 	#instVars : [
-		'operations',
-		'model'
+		'operations'
 	],
 	#category : #'Magritte-Merging'
 }
+
+{ #category : #accessing }
+MAPatchMacro class >> example [
+	<gtExample>
+	^ self
+		given: [ self new ]
+		when: [ :macro |
+			| op |
+			op := MAPatchOperation example.
+			macro operations
+				add: op;
+				add: (MAPatchOperation example2 receiver: op receiver; yourself).
+			macro ]
+		then: [ :macro |
+			macro operations size should equal: 2 ]
+]
+
+{ #category : #accessing }
+MAPatchMacro >> addOperationFor: modelObject set: aDescription to: valueObject [
+	| newOp |
+	newOp := MAPatchOperation
+		for: modelObject
+		set: aDescription
+		to: valueObject.
+	^ self operations add: newOp.
+]
+
+{ #category : #accessing }
+MAPatchMacro >> asElement [
+	^ MAPatchMacroElement on: self
+]
 
 { #category : #accessing }
 MAPatchMacro >> children [
@@ -21,6 +51,7 @@ MAPatchMacro >> descriptionOperations [
 		accessor: #operations;
 		glmPresentation: [ :a | a list ];
 		classes: { MAPatchOperation };
+		default: OrderedCollection new;
 		yourself
 ]
 
@@ -47,35 +78,14 @@ MAPatchMacro >> execute [
 { #category : #accessing }
 MAPatchMacro >> gtElementViewFor: aView [
 	<gtView>
-	^ aView explicit stencil: [
-		| el |
-		el := BlElement new
-			layout: (BlLinearLayout vertical cellSpacing: 10);
-			constraintsDo: [ :c | 
-				c horizontal fitContent.
-				c vertical fitContent ].
-		self operations do: [ :op | el addChild: op asElement ].
-		el addChild: (BrButton new
-				beSmallSize;
-				aptitude: BrGlamorousButtonWithLabelAptitude;
-				label: 'Apply';
-				action: [ self execute ]).
-		el ]
-]
-
-{ #category : #execution }
-MAPatchMacro >> model [
-	^ model
+	^ aView explicit 
+		priority: 25;
+		stencil: [ self asElement ]
 ]
 
 { #category : #accessing }
-MAPatchMacro >> model: anObject [
-	model := anObject
-]
-
-{ #category : #execution }
 MAPatchMacro >> operations [
-	^ operations
+	^ self maLazyInstVarUsing: self descriptionOperations
 ]
 
 { #category : #accessing }
@@ -86,12 +96,18 @@ MAPatchMacro >> operations: anObject [
 { #category : #printing }
 MAPatchMacro >> printOn: aStream [
 
-	model 
-		ifNotNil: [ 
-			aStream
-				nextPutAll: 'Patch for ';
-				print: model ]
-		ifNil: [ super printOn: aStream ]
+	self receivers
+		ifNotEmpty: [ :recs |
+			aStream nextPutAll: 'Patch for '.
+			recs
+				do: [ :e | aStream print: e ]
+				separatedBy: [ aStream space ] ]
+		ifEmpty: [ super printOn: aStream ]
+]
+
+{ #category : #accessing }
+MAPatchMacro >> receivers [
+	^ self operations collect: #receiver as: Set
 ]
 
 { #category : #execution }

--- a/source/Magritte-Merging/MAPatchMacroElement.class.st
+++ b/source/Magritte-Merging/MAPatchMacroElement.class.st
@@ -1,0 +1,90 @@
+Class {
+	#name : #MAPatchMacroElement,
+	#superclass : #BlElement,
+	#instVars : [
+		'model',
+		'expander',
+		'header'
+	],
+	#category : #'Magritte-Merging'
+}
+
+{ #category : #'instance creation' }
+MAPatchMacroElement class >> on: macro [
+	^ self new
+		model: macro;
+		yourself
+]
+
+{ #category : #accessing }
+MAPatchMacroElement >> initialize [
+	super initialize.
+	
+	"Adapted from GtRefactoringsElement"
+	self 
+		layout: BlFrameLayout new;
+		constraintsDo: [ :c | 
+				c horizontal matchParent.
+				c vertical fitContent ].
+	
+	expander := BrExpander new
+		hMatchParent;
+		vFitContent;
+		aptitude: (GtCoderExpanderAptitude new
+			padding: BlInsets empty;
+			doNotReplaceHeader) + (BrStyleCommonAptitude new
+				expanded: [ :aStyle |
+					aStyle margin: (BlInsets top: 5 left: 5 bottom: 5 right: 5) ];
+				collapsed: [ :aStyle |
+					aStyle margin: (BlInsets top: 5 left: 5 bottom: 0 right: 5) ]);
+		yourself.
+	
+	self addChild: expander.
+	^ self
+]
+
+{ #category : #accessing }
+MAPatchMacroElement >> model [
+	^ model
+]
+
+{ #category : #accessing }
+MAPatchMacroElement >> model: macro [
+	model := macro.
+	
+	expander header: [
+		| label  button |
+		label := BrButton new
+			action: [ expander toggleExpanded ];
+			aptitude: BrGlamorousButtonWithLabelAptitude;
+			label: self model printString.
+		button := BrButton new
+				beSmallSize;
+				aptitude: BrGlamorousButtonWithLabelAptitude;
+				label: 'Apply';
+				action: [ self model execute ].
+		BlElement new
+			"aptitude: BrGlamorousAccordionHeaderAptitude new;"
+			layout: (BlLinearLayout horizontal cellSpacing: 10);
+			constraintsDo: [ :c | 
+				c horizontal fitContent.
+				c vertical fitContent ];
+			addChild: label;
+			addChild: button;
+			yourself ].
+	
+	expander content: [ 
+		| content | 
+		content := BlElement new
+			layout: (BlLinearLayout vertical cellSpacing: 10);
+			constraintsDo: [ :c | 
+				c horizontal fitContent.
+				c vertical fitContent ].
+		self model operations do: [ :op | content addChild: op asElement ].
+		content ].
+]
+
+{ #category : #accessing }
+MAPatchMacroElement >> rule: aRule targetingGroup: group [
+	self model: aRule patch
+]

--- a/source/Magritte-Merging/MAPatchOperation.class.st
+++ b/source/Magritte-Merging/MAPatchOperation.class.st
@@ -19,11 +19,17 @@ MAPatchOperation class >> example [
 ]
 
 { #category : #examples }
+MAPatchOperation class >> example2 [
+	| desc |
+	desc := MAContainer samplePersonDescription.
+	^ MAPatchOperation for: MAContainer samplePersonHarryPotter set: desc children second to: 'Godric''s Hollow, England'
+]
+
+{ #category : #examples }
 MAPatchOperation class >> for: anObject set: aDescription to: anotherObject [
 	^ self new
 		receiver: anObject; 
 		field: aDescription;
-		oldValue: (anObject readUsing: aDescription);
 		newValue: anotherObject;
 		yourself
 ]
@@ -70,6 +76,12 @@ MAPatchOperation >> asElement [
 ]
 
 { #category : #accessing }
+MAPatchOperation >> cacheOldValue [
+	(self receiver isNil or: [ self field isNil ]) ifTrue: [ ^ self ].
+	self oldValue: (self receiver readUsing: self field)
+]
+
+{ #category : #accessing }
 MAPatchOperation >> children [
 	^ #()
 ]
@@ -92,7 +104,8 @@ MAPatchOperation >> field [
 
 { #category : #accessing }
 MAPatchOperation >> field: anObject [
-	field := anObject
+	field := anObject.
+	self cacheOldValue
 ]
 
 { #category : #accessing }
@@ -160,7 +173,8 @@ MAPatchOperation >> receiver [
 
 { #category : #accessing }
 MAPatchOperation >> receiver: anObject [
-	receiver := anObject
+	receiver := anObject.
+	self cacheOldValue
 ]
 
 { #category : #execution }


### PR DESCRIPTION
- Examples
- Cache Old Value for All Creation Paths; We were doing it only from instance creation method, but this won't work e.g. via metamodel
- Macros
  - Add operation(s) dynamically
  - Better view (expand/collapse w descriptive header)
  - [Clean]: Replace unused and nonsensical `model` with `receivers`
  - [Enh]: Better printing
  - Element