### PR TITLE
[Enh]: Bloc Memo Elements should be Editors, Not Labels

### DIFF
--- a/source/Magritte-GToolkit/MACompositeElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MACompositeElementBuilder.class.st
@@ -1,3 +1,8 @@
+"
+I build a form for an object described by an {{gtClass:MAContainer}} whose children are  {{gtClass:MACompositeAccessor}}s. Here's an example: {{gtExample:MACompositeElementBuilder class>>#example}}
+
+See {{gtClass:MACompositeAccessor}} for more info.
+"
 Class {
 	#name : #MACompositeElementBuilder,
 	#superclass : #MAElementBuilder,
@@ -11,22 +16,9 @@ MACompositeElementBuilder class >> example [
 		object: { #people -> { 
 			MAContainer samplePersonHarryPotter.
 			MAContainer samplePersonDumbledore } } asDictionary;
-		objectDescription: self sampleDescription;
+		objectDescription: MACompositeAccessor sampleContainer;
 		addButtons;
 		element
-]
-
-{ #category : #'example support' }
-MACompositeElementBuilder class >> sampleDescription [
-	| desc |
-	desc := MAContainer sampleDescription
-		blocClass: MACompositeElementBuilder;
-		yourself.
-	desc children do: [ :e | 
-		| acc prefixAccessor |
-		prefixAccessor := MADictionaryAccessor key: #people.
-		acc := MACompositeAccessor via: prefixAccessor using: e ].
-	^ desc
 ]
 
 { #category : #accessing }

--- a/source/Magritte-GToolkit/MAElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MAElementBuilder.class.st
@@ -293,8 +293,23 @@ MAElementBuilder >> visitMagnitudeDescription: anObject [
 ]
 
 { #category : #'visiting-description' }
-MAElementBuilder >> visitMemoDescription: anObject [
-	self visitStringDescription: anObject
+MAElementBuilder >> visitMemoDescription: aDescription [
+	| inputElement lineHeight |
+	self flag: 'Lots of duplication from standard inputElement creation; line height very rough based on 14 pt size - waiting on answer on Discord'.
+	lineHeight := 14 * 1.5.
+	inputElement := BrEditor new
+		beEditable;
+		text: (self textUsing: aDescription);
+		aptitude: BrGlamorousEditorAptitude new glamorousRegularFontAndSize;
+		"vFitContent;"
+		vExact: lineHeight * aDescription lineCount;
+		constraintsDo: [ :c | 
+			c horizontal matchParent.
+			c grid vertical alignCenter ].
+	inputElement editor when: BrTextEditorModifiedEvent
+			do: [ :event | aDescription writeFromString: event text greaseString to: self memento ].
+	
+	self addInputField: inputElement using: aDescription
 ]
 
 { #category : #'visiting-description' }

--- a/source/Magritte-Merging/MAPatchMacroElement.class.st
+++ b/source/Magritte-Merging/MAPatchMacroElement.class.st
@@ -9,6 +9,12 @@ Class {
 	#category : #'Magritte-Merging'
 }
 
+{ #category : #examples }
+MAPatchMacroElement class >> example [
+	<gtExample>
+	^ MAPatchMacro example asElement
+]
+
 { #category : #'instance creation' }
 MAPatchMacroElement class >> on: macro [
 	^ self new

--- a/source/Magritte-Model/MACompositeAccessor.class.st
+++ b/source/Magritte-Model/MACompositeAccessor.class.st
@@ -1,3 +1,6 @@
+"
+When you have a ""to-many"" relationship, I describe the flattened collection of its items - something like {{gtMethod:Collection>>#flatCollect:}} meets {{gtClass:MAChainAccessor}}. Here's a usage example {{gtExample:MACompositeElementBuilder class>>#example}}:
+"
 Class {
 	#name : #MACompositeAccessor,
 	#superclass : #MAChainAccessor,
@@ -9,6 +12,20 @@ Class {
 	],
 	#category : #'Magritte-Model-Accessor'
 }
+
+{ #category : #'example support' }
+MACompositeAccessor class >> sampleContainer [
+	
+	| desc |
+	desc := MAContainer samplePersonDescription
+		blocClass: MACompositeElementBuilder;
+		yourself.
+	desc children do: [ :e | 
+		| acc prefixAccessor |
+		prefixAccessor := MADictionaryAccessor key: #people.
+		acc := MACompositeAccessor via: prefixAccessor using: e ].
+	^ desc
+]
 
 { #category : #'instance creation' }
 MACompositeAccessor class >> via: anAccessor using: aDescription [


### PR DESCRIPTION
Per Tudor in GT Discord graphics-general channel:
>> I'm trying to understand the tradeoffs between BrEditorElement as used in the Jenkins snippet.

> An input field expects one to enter text every single time. 
>> and BrEditableLabel as used in the class definition editor

> An editable label allows one to edit, but that happens rarely. The usability needs are different.

Also, some better comments and examples