### PR TITLE
Fix #234 - MAElementRow Should Use Reference

### DIFF
--- a/source/Magritte-Model/MARelationDescription.class.st
+++ b/source/Magritte-Model/MARelationDescription.class.st
@@ -49,11 +49,6 @@ MARelationDescription class >> defaultClasses [
 	^ Set new
 ]
 
-{ #category : #'accessing-defaults' }
-MARelationDescription class >> defaultReference [
-	^ nil
-]
-
 { #category : #visiting }
 MARelationDescription >> acceptMagritte: aVisitor [
 	aVisitor visitRelationDescription: self

--- a/source/Magritte-Morph/MAElementRow.class.st
+++ b/source/Magritte-Morph/MAElementRow.class.st
@@ -86,7 +86,7 @@ MAElementRow >> initialize [
 		cellInset: self cellInset;
 		layoutInset: 0@2.
 	self
-		addMorphBack: (container magritteDescription toString: object) asMorph;
+		addMorphBack: (container magritteDescription reference toString: object) asMorph;
 		addMorphBack: self buildCommands
 ]
 


### PR DESCRIPTION
For relation descriptions, the default reference was overridden to nil. Not sure why that was, but tests still pass removing the override.