### PR TITLE
Enh gt action flexibility

### DIFF
--- a/lepiter/cuv8kex3dqlfsb604nb7ytijp.bak
+++ b/lepiter/cuv8kex3dqlfsb604nb7ytijp.bak
@@ -1,0 +1,150 @@
+{
+	"__schema" : "4.1",
+	"__type" : "page",
+	"children" : {
+		"__type" : "snippets",
+		"items" : [
+			{
+				"__type" : "textSnippet",
+				"children" : {
+					"__type" : "snippets",
+					"items" : [ ]
+				},
+				"createEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"createTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:32:12.973694-05:00"
+					}
+				},
+				"editEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"editTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:32:13.933146-05:00"
+					}
+				},
+				"uid" : {
+					"__type" : "uid",
+					"uidString" : "a9KUrvqPDQCT1TkzDdyZPw=="
+				},
+				"paragraphStyle" : {
+					"__type" : "textStyle"
+				},
+				"string" : "# Actions"
+			},
+			{
+				"__type" : "textSnippet",
+				"children" : {
+					"__type" : "snippets",
+					"items" : [ ]
+				},
+				"createEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"createTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:42:57.174667-05:00"
+					}
+				},
+				"editEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"editTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:49:55.104036-05:00"
+					}
+				},
+				"uid" : {
+					"__type" : "uid",
+					"uidString" : "fE4b1fqPDQCT289dDdyZPw=="
+				},
+				"paragraphStyle" : {
+					"__type" : "textStyle"
+				},
+				"string" : "The default way to specify an object action in GT is to create a method that takes a builder as an argument and is annotated with the `gtAction` pragma. One example is {{gtMethod:Object>>#gtActionSearchFor:}}. \n\nWe provide a message analogous to the pragma, {{gtMethod:MAActionDescription>>#gtAction:}} in which you can write essentially the same code, and  will be added to the other GT actions.\n\nNB. GT's actions are collected in {{gtMethod:ProtoObject>>#gtActions}}. To avoid an override, we hook in one level up in  {{gtMethod:Object>>#gtActions}}. Therefore, Magritte GT actions will not show up in ProtoObject or its subclasses/instances."
+			},
+			{
+				"__type" : "textSnippet",
+				"children" : {
+					"__type" : "snippets",
+					"items" : [ ]
+				},
+				"createEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"createTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:45:48.219058-05:00"
+					}
+				},
+				"editEmail" : {
+					"__type" : "email",
+					"emailString" : "<unknown>"
+				},
+				"editTime" : {
+					"__type" : "time",
+					"time" : {
+						"__type" : "dateAndTime",
+						"dateAndTimeString" : "2021-12-20T14:46:22.888425-05:00"
+					}
+				},
+				"uid" : {
+					"__type" : "uid",
+					"uidString" : "djxN3/qPDQCT3AhaDdyZPw=="
+				},
+				"paragraphStyle" : {
+					"__type" : "textStyle"
+				},
+				"string" : "# Documenter\n\n**NB. Documenter is no longer part of GT and this functionality will be replaced by a Lepiter-based solution**\n\nSimilar to {{gtClass:GtDocumenter}}'s built-in ability to store documents in class comments via {{gtMethod:GtDocument class>>#forClass:}}, you can view and edit fields described by {{gtClass:MAStringDescription}}. For example: ==GtDocument maFor: recipe using: self noteDescription.=\r"
+			}
+		]
+	},
+	"createEmail" : {
+		"__type" : "email",
+		"emailString" : "<unknown>"
+	},
+	"createTime" : {
+		"__type" : "time",
+		"time" : {
+			"__type" : "dateAndTime",
+			"dateAndTimeString" : "2021-07-27T13:57:17.946354-04:00"
+		}
+	},
+	"editEmail" : {
+		"__type" : "email",
+		"emailString" : "<unknown>"
+	},
+	"editTime" : {
+		"__type" : "time",
+		"time" : {
+			"__type" : "dateAndTime",
+			"dateAndTimeString" : "2021-07-27T13:57:17.946354-04:00"
+		}
+	},
+	"pageType" : {
+		"__type" : "namedPage",
+		"title" : "GToolkit Integration"
+	},
+	"uid" : {
+		"__type" : "uuid",
+		"uuid" : "25510856-8084-0d00-b990-29850f742dd9"
+	}
+}

--- a/source/Magritte-GToolkit/MAActionDescription.extension.st
+++ b/source/Magritte-GToolkit/MAActionDescription.extension.st
@@ -2,34 +2,30 @@ Extension { #name : #MAActionDescription }
 
 { #category : #'*Magritte-GToolkit' }
 MAActionDescription >> gtAction: aValuable [
-	"aValuable - optional arguments are the button and this description"
+	"aValuable - optional arguments:
+		- aGtPhlowNoAction (same as the argument to a standard GT action method)
+		- this description
+		- NB. the receiver is *not* passed as an argument, because it should be available in the description creation method"
 
 	^ self propertyAt: #gtAction put: aValuable
 ]
 
 { #category : #'*Magritte-GToolkit' }
-MAActionDescription >> gtActionFor: anObject [
-	| result tooltip |
-	result := GtPhlowNoAction new button.
+MAActionDescription >> gtActionOf: anObject [
 	
-	result action: [ :button |
-		self
-			propertyAt: #gtAction
-			ifPresent: [ :valuable | 
-				valuable cull: button cull: self ]
-			ifAbsent: [ self performOn: anObject ] ].
-	self
-		propertyAt: #gtIcon
-		ifPresent: [ :i | 
-			result icon: i value.
-			tooltip := self label, ': ', self comment ]
+	^ self
+		propertyAt: #gtAction
+		ifPresent: [ :valuable | 
+			valuable cull: GtPhlowAction noAction cull: self ]
 		ifAbsent: [ 
-			result label: self label.
-			tooltip := self comment ].
-	
-	tooltip ifNotEmpty: [ result tooltip: tooltip ].
-	
-	^ result
+			| button |
+			button := GtPhlowAction noAction button.
+			self comment ifNotEmpty: [ :tt | button tooltip: tt ].
+			self icon ifNotNil: [ :icn | button icon: icn ].
+			button
+				action: [ self performOn: anObject ];
+				label: self label;
+				yourself ].
 ]
 
 { #category : #'*Magritte-GToolkit' }

--- a/source/Magritte-GToolkit/Object.extension.st
+++ b/source/Magritte-GToolkit/Object.extension.st
@@ -50,5 +50,5 @@ Object >> magritteElementBuilder [
 
 { #category : #'*Magritte-GToolkit' }
 Object >> magritteGToolkitActions [
-	^ self magritteActions children collect: [ :desc | desc gtActionFor: self ].
+	^ self magritteActions children collect: [ :desc | desc gtActionOf: self ].
 ]


### PR DESCRIPTION
- Valuable passed to `#gtAction:` now gets Null Phlow Action instead of a button. Let's see if it's annoying to manually set the icon and label. Another option would be to pass a partially configured button, because Phlow seems to let you create any type of action from any other.
- Docs - method comments and Lepiter
-  Rename `gtActionFor:` (which means something else, see implementors) to `#gtActionOf:`