### PR TITLE
[Enh]: Object ID Ref - More Robust Equality

### DIFF
--- a/source/Magritte-Model/MAObjectUIDReference.class.st
+++ b/source/Magritte-Model/MAObjectUIDReference.class.st
@@ -21,6 +21,7 @@ Class {
 
 { #category : #accessing }
 MAObjectUIDReference >> = rhs [
+	self species = rhs species ifFalse: [ ^ false ].
 	^ self uid = rhs uid
 ]
 


### PR DESCRIPTION
Check species to avoid errors from deep in the system e.g. during Lepiter materialization