### PR TITLE
PR for green build in Pharo 10

### DIFF
--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -34,7 +34,6 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 	"Common external dependencies for baseline 3.1.0"
 	
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.8.x/repository' ];
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
@@ -45,29 +44,16 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 
 { #category : #baselines }
 BaselineOfMagritte >> baseline330ForPharo: spec [
-	spec for: #squeakCommon do: [ 
-		spec
-			package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo-Model') ];
-			package: 'Magritte-Tests-Model' with: [ spec includes: #('Magritte-Tests-Pharo-Model') ];
-			package: 'Magritte-Pharo-Model' with: [ spec requires: #('Magritte-Model') ];
-			package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo-Model') ];
-			package: 'Magritte-Seaside' with: [ spec includes: #('Magritte-Pharo-Seaside') ];				
-			package: 'Magritte-Pharo-Seaside' with: [ spec requires: #('Magritte-Seaside') ];
-			package: 'Magritte-Morph' with: [ spec requires: #('Magritte-Model') ];
-			package: 'Magritte-Pharo-Tools' with: [ spec requires: #('Magritte-Deprecated') ].
-		spec
-			group: 'Tools' with: #('Magritte-Pharo-Tools');
-			group: 'default' with: #('Magritte-Morph') ].
-				
+			
 	spec for: #(#'pharo9.x' #'pharo10.x') do: [
 		spec
 			package: 'Magritte-Pillar' 
 				with: [ spec requires: #('Magritte-Model') "assumes Pillar is loaded, which is the case in P9 and GT" ] ].
 			
 	spec for: #(#'pharo10.x') do: [ 
-		spec
-			baseline: 'PharoEnhancements' with: [
-				spec repository: 'github://seandenigris/Pharo-Enhancements' ].
+		spec 
+			baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.9.0/repository' ];			
+			baseline: 'PharoEnhancements' with: [ spec repository: 'github://seandenigris/Pharo-Enhancements' ].
 		spec
 			" create a temporary alias "
 			package: 'Magritte-Pharo7-Model'	with: [ spec requires: #('Magritte-Model') ];
@@ -80,8 +66,8 @@ BaselineOfMagritte >> baseline330ForPharo: spec [
 	
 	spec for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x') do: [ 
 		spec
-			baseline: 'PharoEnhancements' with: [
-				spec repository: 'github://seandenigris/Pharo-Enhancements' ].
+			baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.8.x/repository' ];		
+			baseline: 'PharoEnhancements' with: [ spec repository: 'github://seandenigris/Pharo-Enhancements' ].
 		spec
 			" create a temporary alias "
 			package: 'Magritte-Pharo7-Model';
@@ -103,6 +89,25 @@ BaselineOfMagritte >> baseline330ForPharo: spec [
 			package: 'Magritte-Merging-Bloc' with: [ spec requires: #('Magritte-Merging') ];
 			package: 'Magritte-UI' with: [ spec requires: #('Magritte-Model') ].
 		spec group: 'default' with: #(#'Magritte-GToolkit' 'Magritte-Merging-Bloc') ]
+]
+
+{ #category : #baselines }
+BaselineOfMagritte >> baseline330ForSqueak: spec [
+
+	spec for: #squeakCommon do: [ 
+		spec
+			package: 'Magritte-Model' with: [ spec includes: #('Magritte-Pharo-Model') ];
+			package: 'Magritte-Tests-Model' with: [ spec includes: #('Magritte-Tests-Pharo-Model') ];
+			package: 'Magritte-Pharo-Model' with: [ spec requires: #('Magritte-Model') ];
+			package: 'Magritte-Tests-Pharo-Model' with: [ spec requires: #('Magritte-Pharo-Model') ];
+			package: 'Magritte-Seaside' with: [ spec includes: #('Magritte-Pharo-Seaside') ];				
+			package: 'Magritte-Pharo-Seaside' with: [ spec requires: #('Magritte-Seaside') ];
+			package: 'Magritte-Morph' with: [ spec requires: #('Magritte-Model') ];
+			package: 'Magritte-Pharo-Tools' with: [ spec requires: #('Magritte-Deprecated') ].
+		spec
+			group: 'Tools' with: #('Magritte-Pharo-Tools');
+			group: 'default' with: #('Magritte-Morph') ].
+
 ]
 
 { #category : #baselines }
@@ -134,6 +139,7 @@ BaselineOfMagritte >> baseline: spec [
 				group: 'Seaside' with: #('Magritte-Seaside');
 				group: 'Deprecated' with: #('Magritte-Deprecated') ].
 	self baseline330ForPharo: spec.
+	self baseline330ForSqueak: spec.
 	self baseline300ForGemStone: spec
 ]
 

--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -34,6 +34,7 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 	"Common external dependencies for baseline 3.1.0"
 	
 	spec
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.9.0/repository' ];	
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec
@@ -52,7 +53,6 @@ BaselineOfMagritte >> baseline330ForPharo: spec [
 			
 	spec for: #(#'pharo10.x') do: [ 
 		spec 
-			baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.9.0/repository' ];			
 			baseline: 'PharoEnhancements' with: [ spec repository: 'github://seandenigris/Pharo-Enhancements' ].
 		spec
 			" create a temporary alias "
@@ -66,7 +66,6 @@ BaselineOfMagritte >> baseline330ForPharo: spec [
 	
 	spec for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x') do: [ 
 		spec
-			baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.8.x/repository' ];		
 			baseline: 'PharoEnhancements' with: [ spec repository: 'github://seandenigris/Pharo-Enhancements' ].
 		spec
 			" create a temporary alias "
@@ -92,7 +91,7 @@ BaselineOfMagritte >> baseline330ForPharo: spec [
 ]
 
 { #category : #baselines }
-BaselineOfMagritte >> baseline330ForSqueak: spec [
+BaselineOfMagritte >> baseline330ForSqueakCommon: spec [
 
 	spec for: #squeakCommon do: [ 
 		spec
@@ -139,7 +138,7 @@ BaselineOfMagritte >> baseline: spec [
 				group: 'Seaside' with: #('Magritte-Seaside');
 				group: 'Deprecated' with: #('Magritte-Deprecated') ].
 	self baseline330ForPharo: spec.
-	self baseline330ForSqueak: spec.
+	self baseline330ForSqueakCommon: spec.
 	self baseline300ForGemStone: spec
 ]
 


### PR DESCRIPTION
Currently in Pharo 10, only a few tests pass because Magritte uses a previous version of Grease (Grease:v1.8.x)

> 1727 ran, 126 passed, 0 skipped, 0 expected failures, 0 failures, 1601 errors, 0 passed unexpected

This PR update the Baseline to use Grease:v1.9.0 and all tests pass now:

> 1727 ran, 1727 passed, 0 skipped, 0 expected failures, 0 failures, 0 errors, 0 passed unexpected.

To reproduce it in a clean Pharo 10 image:

```smalltalk
EpMonitor disableDuring: [ 	
		Metacello new
 		baseline: 'Magritte';
		repository: 'github://hernanmd/magritte:pharo10-ready/source';
		load: 'Tests' ].
```

And run the Magritte tests
