### PR TITLE
[Feature]: Bloc ToOne Relations Spotter Support

### DIFF
--- a/source/Magritte-GToolkit/MAElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MAElementBuilder.class.st
@@ -448,8 +448,23 @@ MAElementBuilder >> visitToManyScalarRelationDescription: anObject [
 ]
 
 { #category : #'visiting-description' }
-MAElementBuilder >> visitToOneRelationDescription: anObject [
-	self visitRelationDescription: anObject
+MAElementBuilder >> visitToOneRelationDescription: aDescription [
+	| inputElement valueLabel searchButton |
+	
+	aDescription gtSearchSource ifNil: [ ^ self visitRelationDescription: aDescription ].
+	
+	inputElement := MATokenCollectorElement new
+		relationDescription: aDescription;
+		tokenClickAction: [ :evt | 
+			(self object readUsing: aDescription)
+				ifNotNil: [ :obj | evt target phlow spawnObject: obj ] ];
+		spotterAction: [ :evt :colElem | 
+			aDescription write: evt element to: self memento.
+			colElem valueLabel text: (self textUsing: aDescription) ].	
+	
+	inputElement valueLabel text: (self textUsing: aDescription).
+		
+	self addInputField: inputElement using: aDescription
 ]
 
 { #category : #'visiting-description' }

--- a/source/Magritte-GToolkit/MATokenCollectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenCollectorElement.class.st
@@ -1,0 +1,95 @@
+Class {
+	#name : #MATokenCollectorElement,
+	#superclass : #BrHorizontalPane,
+	#instVars : [
+		'relationDescription',
+		'spotterAction',
+		'tokenClickAction',
+		'valueLabel'
+	],
+	#category : #'Magritte-GToolkit-Widgets'
+}
+
+{ #category : #initialization }
+MATokenCollectorElement >> initialize [
+
+	| searchButton |
+	super initialize.
+	
+	self
+		hMatchParent;
+		padding: (BlInsets top: 4 bottom: 4);
+		alignCenterLeft;
+		cellSpacing: 5;
+		vFitContent.
+		
+	valueLabel := BrLabel new
+		aptitude: BrGlamorousLabelAptitude;
+		beSmallSize;
+		addEventHandlerOn: BlClickEvent
+			do: [ :evt | self tokenClickAction cull: evt ];
+		yourself.
+		
+	searchButton := GtSpotterDropdownButtonStencil new
+		valuable: [ self relationDescription gtSearchSource value ];
+		icon: BrGlamorousVectorIcons search;
+		spotterModelDo: [ :sm |
+			sm announcer
+				when: GtSpotterActOn
+				do: [ :evt | 
+					self spotterAction cull: evt cull: self.
+					evt actedUpon: true ] ];
+		create.
+	
+	self
+		addChild: valueLabel;
+		addChild: searchButton.
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> relationDescription [
+
+	^ relationDescription
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> relationDescription: anObject [
+
+	relationDescription := anObject
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> spotterAction [
+
+	^ spotterAction
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> spotterAction: anObject [
+
+	spotterAction := anObject
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> tokenClickAction [
+
+	^ tokenClickAction
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> tokenClickAction: anObject [
+
+	tokenClickAction := anObject
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> valueLabel [
+
+	^ valueLabel
+]
+
+{ #category : #accessing }
+MATokenCollectorElement >> valueLabel: anObject [
+
+	valueLabel := anObject
+]

--- a/source/Magritte-Model/MAReferenceDescription.class.st
+++ b/source/Magritte-Model/MAReferenceDescription.class.st
@@ -81,6 +81,16 @@ MAReferenceDescription >> descriptionReference [
 ]
 
 { #category : #accessing }
+MAReferenceDescription >> gtSearchSource [
+	^ self propertyAt: #gtSearchSource ifAbsent: [ nil ]
+]
+
+{ #category : #accessing }
+MAReferenceDescription >> gtSearchSource: valuable [
+	self propertyAt: #gtSearchSource put: valuable
+]
+
+{ #category : #accessing }
 MAReferenceDescription >> initializer [
 	^ self propertyAt: #initializer ifAbsent: [ #yourself ]
 ]


### PR DESCRIPTION
Nice way to choose from available objects, or even add a new one, depending on the spotters that are passed. It'd be nicer to utilize auto-complete, as opposed to the current button, but it seems GT currently only has auto-complete for code editors, not all text editors.