### PR TITLE
[Bug]: Cached Memento Should Copy ToMany Collections

### DIFF
--- a/source/Magritte-Model/MACachedMemento.class.st
+++ b/source/Magritte-Model/MACachedMemento.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'cache'
 	],
-	#category : 'Magritte-Model-Memento'
+	#category : #'Magritte-Model-Memento'
 }
 
 { #category : #testing }
@@ -25,6 +25,15 @@ MACachedMemento >> commit [
 	super commit.
 	self push: self cache.
 	self reset
+]
+
+{ #category : #private }
+MACachedMemento >> cookRawPull: aDictionary [
+
+	aDictionary keysAndValuesDo: [ :key :value |
+		| isCollectionOfRelations |
+		isCollectionOfRelations := value isCollection and: [ key isKindOf: MAToManyRelationDescription ].
+		isCollectionOfRelations ifTrue: [ aDictionary at: key put: value copy ] ].
 ]
 
 { #category : #testing }

--- a/source/Magritte-Model/MACachedMemento.class.st
+++ b/source/Magritte-Model/MACachedMemento.class.st
@@ -30,6 +30,7 @@ MACachedMemento >> commit [
 { #category : #private }
 MACachedMemento >> cookRawPull: aDictionary [
 
+	super cookRawPull: aDictionary.
 	aDictionary keysAndValuesDo: [ :key :value |
 		| isCollectionOfRelations |
 		isCollectionOfRelations := value isCollection and: [ key isKindOf: MAToManyRelationDescription ].

--- a/source/Magritte-Model/MAMemento.class.st
+++ b/source/Magritte-Model/MAMemento.class.st
@@ -33,6 +33,14 @@ MAMemento >> commit [
 	"Commit the receiver into the model."
 ]
 
+{ #category : #private }
+MAMemento >> cookRawPull: aDictionary [
+
+	aDictionary keysAndValuesDo: [ :key :value |
+		value isNil
+			ifTrue: [ aDictionary at: key put: key default yourself ] ]
+]
+
 { #category : #'reflective operations' }
 MAMemento >> doesNotUnderstand: aMessage [
   ^ self magritteDescription children 
@@ -75,9 +83,7 @@ MAMemento >> pull [
 
 	| result |
 	result := self pullRaw.
-	result keysAndValuesDo: [ :key :value |
-		value isNil
-			ifTrue: [ result at: key put: key default yourself ] ].
+	self cookRawPull: result.
 	^ result
 ]
 


### PR DESCRIPTION
Currently, the cache stores the actual collection from the described object. If the cache's collection is modified, the object is modified too. This invalidates the protection of the cache.

NB. Includes type check. This is WIP because it may need to be extended to options. Once that is clear, we'll remove the type check