### PR TITLE
[Feature]: Reference GT Searches - Delegate to another object

### DIFF
--- a/source/Magritte-GToolkit/MAGtDelegatedSearch.class.st
+++ b/source/Magritte-GToolkit/MAGtDelegatedSearch.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #MAGtDelegatedSearch,
+	#superclass : #Object,
+	#instVars : [
+		'delegate',
+		'message'
+	],
+	#category : #'Magritte-GToolkit'
+}
+
+{ #category : #'magritte-descriptions' }
+MAGtDelegatedSearch class >> to: aValuable message: aSymbol [ 
+
+	^ self new
+		delegate: aValuable;
+		message: aSymbol;
+		yourself
+]
+
+{ #category : #accessing }
+MAGtDelegatedSearch >> delegate [
+
+	^ delegate
+]
+
+{ #category : #accessing }
+MAGtDelegatedSearch >> delegate: aValuable [
+
+	delegate := aValuable
+]
+
+{ #category : #accessing }
+MAGtDelegatedSearch >> gtSpotterOn: aStep [
+	<gtSearch>
+	
+	^ self delegate value perform: self message with: aStep
+]
+
+{ #category : #accessing }
+MAGtDelegatedSearch >> message [
+
+	^ message
+]
+
+{ #category : #accessing }
+MAGtDelegatedSearch >> message: anObject [
+
+	message := anObject
+]

--- a/source/Magritte-Model/MAReferenceDescription.class.st
+++ b/source/Magritte-Model/MAReferenceDescription.class.st
@@ -81,6 +81,15 @@ MAReferenceDescription >> descriptionReference [
 ]
 
 { #category : #accessing }
+MAReferenceDescription >> gtSearchDelegateTo: anObjectValuable message: aSymbol [
+	| source |
+	source := MAGtDelegatedSearch 
+		to: anObjectValuable 
+		message: aSymbol.
+	self gtSearchSource: source
+]
+
+{ #category : #accessing }
 MAReferenceDescription >> gtSearchSource [
 	^ self propertyAt: #gtSearchSource ifAbsent: [ nil ]
 ]


### PR DESCRIPTION
Let's say you have a person object with an `addresses` field. In a person's Magritte form, you want to have Spotter completion to create new addresses. What makes this a bit special is that an address probably doesn't live in a special collection, so there is probably no object that defines a suitable Spotter.

By doing `anMAReferenceDescription gtSearchDelegateTo: anObject message: aSymbol`, you can have any object stand in to supply the Spotter