### PR TITLE
[Enh]: String Camel Case Normalization - Handle Acronyms

### DIFF
--- a/source/Magritte-Model/String.extension.st
+++ b/source/Magritte-Model/String.extension.st
@@ -13,6 +13,8 @@ String >> normalizeCamelCase [
 
 	^ self class streamContents: [ :out |
 		self do: [ :e |
-			(e isUppercase and: [ out position > 0 ]) ifTrue: [ out nextPut: Character space ].
+			| isNewWord |
+			isNewWord := e isUppercase and: [ out position > 0 and: [ out peekLast isUppercase not ] ].
+			isNewWord ifTrue: [ out nextPut: Character space ].
 			out nextPut: e ] ]
 ]


### PR DESCRIPTION
e.g. `RlPDF` -> 'Rl PDF', not 'Rl P D F'