### PR TITLE
[Bug]: Cached Memento Should Copy Fields

### DIFF
--- a/source/Magritte-Model/MACachedMemento.class.st
+++ b/source/Magritte-Model/MACachedMemento.class.st
@@ -40,7 +40,7 @@ MACachedMemento >> cookRawPull: aDictionary [
 ]
 
 { #category : #testing }
-MACachedMemento >> hasChanged [
+MACachedMemento >> hasChanges [
 	"Answer ==true==, if the cached data is different to the data in the model."
 
 	^ self isDifferent: self cache to: self pullRaw

--- a/source/Magritte-Model/MACheckedMemento.class.st
+++ b/source/Magritte-Model/MACheckedMemento.class.st
@@ -14,7 +14,12 @@ Class {
 MACheckedMemento >> hasConflict [
 	"Answer ==true==, if there is an edit conflict."
 
-	^ self hasChanged and: [ self isDifferent: self original to: self pullRaw ]
+	^ self hasChanges and: [ self hasModelChangedElsewhere ]
+]
+
+{ #category : #testing }
+MACheckedMemento >> hasModelChangedElsewhere [
+	^ self isDifferent: self original to: self pullRaw
 ]
 
 { #category : #accessing }
@@ -36,14 +41,10 @@ MACheckedMemento >> setOriginal: aDictionary [
 { #category : #'private-testing' }
 MACheckedMemento >> shouldPush: anObject using: aDescription [
 
-	| originalValue cachedValue hasValueChanged isCollectionOfRelations |
+	| originalValue cachedValue |
 	originalValue := self original at: aDescription.
 	cachedValue := self cache at: aDescription.
-	isCollectionOfRelations := originalValue isCollection and: [ aDescription isKindOf: MAToManyRelationDescription ].
-	hasValueChanged := isCollectionOfRelations
-		ifTrue: [ (originalValue = cachedValue) not ]
-		ifFalse: [ (originalValue == cachedValue) not ].
-	^ hasValueChanged and: [ super shouldPush: anObject using: aDescription ]
+	^ (originalValue = cachedValue) not and: [ super shouldPush: anObject using: aDescription ]
 ]
 
 { #category : #actions }

--- a/source/Magritte-Model/MAMemento.class.st
+++ b/source/Magritte-Model/MAMemento.class.st
@@ -92,12 +92,9 @@ MAMemento >> pullRaw [
 	| result |
 	result := Dictionary new.
 	self magritteDescription do: [ :each |
-		| value isCollectionOfRelations |
+		| value |
 		value := self model readUsing: each.
-		self flag: 'duplicate logic with cookRawPull:'.
-		isCollectionOfRelations := value isCollection and: [ each isKindOf: MAToManyRelationDescription ].
-		isCollectionOfRelations ifTrue: [ value := value copy ].
-		result at: each put: value ].
+		result at: each put: value copy ].
 	^ result
 ]
 

--- a/source/Magritte-Tests-Model/MACachedMementoTest.class.st
+++ b/source/Magritte-Tests-Model/MACachedMementoTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MACachedMementoTest,
 	#superclass : #MAMementoTest,
-	#category : 'Magritte-Tests-Model-Memento'
+	#category : #'Magritte-Tests-Model-Memento'
 }
 
 { #category : #testing }
@@ -24,12 +24,12 @@ MACachedMementoTest >> testCommit [
 	self write: self includedInstance.
 	self assert: self read = self includedInstance.
 	self assert: self value = self nullInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 
 	self memento commit.
 	self assert: self read = self includedInstance.
 	self assert: self value = self includedInstance.
-	self deny: self memento hasChanged
+	self deny: self memento hasChanges
 ]
 
 { #category : #'tests-basic' }
@@ -44,12 +44,12 @@ MACachedMementoTest >> testRead [
 MACachedMementoTest >> testReset [
 	self value: self defaultInstance.
 	self write: self includedInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 
 	self memento reset.
 	self assert: self read = self defaultInstance.
 	self assert: self value = self defaultInstance.
-	self deny: self memento hasChanged
+	self deny: self memento hasChanges
 ]
 
 { #category : #'tests-basic' }

--- a/source/Magritte-Tests-Model/MACheckedMementoTest.class.st
+++ b/source/Magritte-Tests-Model/MACheckedMementoTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MACheckedMementoTest,
 	#superclass : #MACachedMementoTest,
-	#category : 'Magritte-Tests-Model-Memento'
+	#category : #'Magritte-Tests-Model-Memento'
 }
 
 { #category : #testing }
@@ -18,18 +18,18 @@ MACheckedMementoTest >> actualClass [
 MACheckedMementoTest >> testConflictCommit [
 	self write: self includedInstance.
 	self assert: self read = self includedInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 	self deny: self memento hasConflict.
 
 	self value: self otherInstance.
 	self assert: self read = self includedInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 	self assert: self memento hasConflict.
 
 	self memento commit.
 	self assert: self read = self includedInstance.
 	self assert: self value = self includedInstance.
-	self deny: self memento hasChanged.
+	self deny: self memento hasChanges.
 	self deny: self memento hasConflict
 ]
 
@@ -37,18 +37,18 @@ MACheckedMementoTest >> testConflictCommit [
 MACheckedMementoTest >> testConflictReset [
 	self write: self includedInstance.
 	self assert: self read = self includedInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 	self deny: self memento hasConflict.
 
 	self value: self otherInstance.
 	self assert: self read = self includedInstance.
-	self assert: self memento hasChanged.
+	self assert: self memento hasChanges.
 	self assert: self memento hasConflict.
 
 	self memento reset.
 	self assert: self read = self otherInstance.
 	self assert: self value = self otherInstance.
-	self deny: self memento hasChanged.
+	self deny: self memento hasChanges.
 	self deny: self memento hasConflict
 ]
 


### PR DESCRIPTION
For example, to check if the model has changed elsewhere, it does:
```smalltalk
self isDifferent: self original to: self pullRaw
```

But if the field values were not copied, this seemingly has no meaning for complex objects, because any changes to them from outside will be reflected equally in the `original` dictionary. E.g. if `original at: #person == self model person` and outside someone does `self model person age: 25`the check above will pass even though it should fail.