### PR TITLE
Updates for Pharo 10

### DIFF
--- a/source/Magritte-Morph/MAElementRow.class.st
+++ b/source/Magritte-Morph/MAElementRow.class.st
@@ -25,7 +25,7 @@ MAElementRow class >> for: anObject of: aDescriptionMorph [
 
 { #category : #private }
 MAElementRow >> buildButton: aSymbol [
-	^ Smalltalk ui theme builder
+	^ self theme builder
 		newButtonFor: self
 		action: aSymbol
 		label: aSymbol capitalized

--- a/source/Magritte-Morph/MAMorphicCheckbox.class.st
+++ b/source/Magritte-Morph/MAMorphicCheckbox.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #private }
 MAMorphicCheckbox >> buildMorphView [
-	^ Smalltalk ui theme
+	^ self theme
 		newCheckboxIn: nil
 		for: self
 		getSelected: #selected

--- a/source/Magritte-Morph/MAMorphicDate.class.st
+++ b/source/Magritte-Morph/MAMorphicDate.class.st
@@ -6,12 +6,10 @@ Class {
 
 { #category : #'private-building' }
 MAMorphicDate >> buildMorphView [
-	| model |
-	model := DateModel new
-		displayBlock: [ :e | self magritteDescription toString: e ];
-		date: self value;
-		whenDateChanged: [ :newDate | self value: newDate ];
-		yourself.
-	^ model buildWithSpec
-			yourself.
+
+	^ SpDatePresenter new
+		  display: [ :e | self magritteDescription toString: e ];
+		  date: self value;
+		  whenDateChanged: [ :newDate | self value: newDate ];
+		  build
 ]

--- a/source/Magritte-Morph/MAMorphicDropList.class.st
+++ b/source/Magritte-Morph/MAMorphicDropList.class.st
@@ -6,17 +6,14 @@ Class {
 
 { #category : #'private-building' }
 MAMorphicDropList >> buildMorphView [
-	
-	| list |
-	list := DropListModel new.
-	list
-		items: self options;
-		displayBlock: [ :e | 
-			e
-				ifNil: [ '' ]
-				ifNotNil: [ self magritteDescription reference toString: e ] ];
-		setSelectedItem: self value;
-		whenSelectedItemChanged: [ :e | self value: e ].
-	
-	^ list buildWithSpec.
+
+	^ SpDropListPresenter new
+		  items: self options;
+		  display: [ :e | 
+			  e
+				  ifNil: [ '' ]
+				  ifNotNil: [ self magritteDescription reference toString: e ] ];
+		  selectItem: self value;
+		  whenSelectedItemChangedDo: [ :e | self value: e ];
+		  build
 ]

--- a/source/Magritte-Morph/MAMorphicMultiSelectList.class.st
+++ b/source/Magritte-Morph/MAMorphicMultiSelectList.class.st
@@ -8,12 +8,6 @@ Class {
 }
 
 { #category : #private }
-MAMorphicMultiSelectList >> buildMorph [
-		
-	^ super buildMorph.
-]
-
-{ #category : #private }
 MAMorphicMultiSelectList >> buildMorphView [
 	^ (PluggableListMorph on: self list: #strings primarySelection: #selected changePrimarySelection: #selected: listSelection: #selectionAt: changeListSelection: #selectionAt:put: menu: nil)
 		hResizing: #spaceFill;

--- a/source/Magritte-Morph/MAMorphicOneToMany.class.st
+++ b/source/Magritte-Morph/MAMorphicOneToMany.class.st
@@ -52,7 +52,7 @@ MAMorphicOneToMany >> buildMorphView [
 
 { #category : #private }
 MAMorphicOneToMany >> buildSelectButton [
-	^ Smalltalk ui theme builder
+	^ self theme builder
 		newButtonFor: self
 		action: #add
 		label: 'Add'

--- a/source/Magritte-Morph/MAMorphicOneToOne.class.st
+++ b/source/Magritte-Morph/MAMorphicOneToOne.class.st
@@ -4,7 +4,7 @@ Class {
 	#category : #'Magritte-Morph-Model'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 MAMorphicOneToOne >> buildMorphView [
 
 	| table |
@@ -19,7 +19,7 @@ MAMorphicOneToOne >> buildMorphView [
 
 { #category : #private }
 MAMorphicOneToOne >> buildSelectButton [
-	^ Smalltalk ui theme builder
+	^ self theme builder
 		newButtonFor: self
 		action: #create
 		label: 'Create'

--- a/source/Magritte-Morph/MAMorphicRelation.class.st
+++ b/source/Magritte-Morph/MAMorphicRelation.class.st
@@ -19,7 +19,7 @@ MAMorphicRelation >> addSelectListTo: aMorph [
 MAMorphicRelation >> buildClassChooser [
 	| items |
 	items := self classes collect: [ :e | e label ].
-	^ Smalltalk ui theme builder
+	^ self theme builder
 		newDropListFor: self
 		list: items
 		getSelected: #selectedIndex

--- a/source/Magritte-Morph/MAMorphicText.class.st
+++ b/source/Magritte-Morph/MAMorphicText.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #private }
 MAMorphicText >> buildMorphView [
-	^ Smalltalk ui theme
+	^ self theme
 		newTextEntryIn: nil
 		for: self
 		get: #string

--- a/source/Magritte-Morph/SpDatePresenter.extension.st
+++ b/source/Magritte-Morph/SpDatePresenter.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #SpDatePresenter }
+
+{ #category : #'*Magritte-Morph' }
+SpDatePresenter >> whenDateChanged: aBlock [
+
+	self flag:
+		'Hotfix for broken Spec2 method. Remove this method and let it be replaced by original Spec2 one once it is fixed in Spec2 and the fix is properly applied in all relevant versions of Pharo. See https://github.com/pharo-spec/Spec/issues/1302'.
+
+	dateModel whenTextChangedDo: [ :newText :oldText | 
+		| oldDate |
+		oldDate := date.
+		date := newText
+			        ifNotEmpty: [ Date readFrom: newText readStream ]
+			        ifEmpty: [ nil ].
+		aBlock cull: date cull: oldDate ]
+]

--- a/source/Magritte-Morph/TokenCollectorMorph.class.st
+++ b/source/Magritte-Morph/TokenCollectorMorph.class.st
@@ -12,7 +12,7 @@ Class {
 		'whenObjectsChangedBlock',
 		'factory'
 	],
-	#category : 'Magritte-Morph-Morphs'
+	#category : #'Magritte-Morph-Morphs'
 }
 
 { #category : #private }
@@ -137,7 +137,7 @@ TokenCollectorMorph >> tokenViewer [
 	tokenViewer ifNotNil: [ ^ tokenViewer ].
 	^ tokenViewer := Morph new
 		color:
-			Smalltalk ui theme backgroundColor;
+			self theme backgroundColor;
 		changeTableLayout;
 		vResizing: #shrinkWrap;
 		hResizing: #spaceFill;

--- a/source/Magritte-Morph/TokenCollectorMorph.class.st
+++ b/source/Magritte-Morph/TokenCollectorMorph.class.st
@@ -31,9 +31,14 @@ TokenCollectorMorph >> entryCompletion [
 
 	entryCompletion ifNotNil: [ ^ entryCompletion ].
 	^ entryCompletion := EntryCompletion new
-			dataSourceBlock: [ :currText | self options collect: self stringEncoder ];
-			filterBlock: [ :currApplicant :currText | currApplicant asString asUppercase includesSubstring: currText asString asUppercase ];
-			yourself.
+		                     dataSourceBlock: [ :currText | 
+			                     self options collect: self stringEncoder ];
+		                     filterBlock: [ :currApplicant :currText | 
+			                     currApplicant asString asUppercase 
+				                     includesSubstring:
+					                     currText asString asUppercase ];
+		                     chooseBlock: [ :text | self accept: text ];
+		                     yourself
 ]
 
 { #category : #accessing }
@@ -122,10 +127,10 @@ TokenCollectorMorph >> stringEncoder: aBlock [
 TokenCollectorMorph >> textInput [
 
 	textInput ifNotNil: [ ^ textInput ].
-	textInput := TextInputFieldModel new
-		entryCompletion: self entryCompletion;
-		acceptBlock: [ :text | self accept: text ];
-		buildWithSpec.
+	textInput := SpTextInputFieldPresenter new
+		             entryCompletion: self entryCompletion;
+		             whenSubmitDo: [ :text | self accept: text ];
+		             build.
 	textInput
 		vResizing: #rigid;
 		height: textInput textFont height + (textInput borderWidth * 2).

--- a/source/Magritte-Morph/TokenMorph.class.st
+++ b/source/Magritte-Morph/TokenMorph.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'object'
 	],
-	#category : 'Magritte-Morph-Morphs'
+	#category : #'Magritte-Morph-Morphs'
 }
 
 { #category : #'instance creation' }
@@ -21,7 +21,7 @@ TokenMorph >> initialize [
 	self roundedCorners: #(1 2 3 4).	"Seems to do nothing"
 	self
 		color:
-			Smalltalk ui theme buttonColor;
+			self theme buttonColor;
 		changeTableLayout;
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap;


### PR DESCRIPTION
Multiple fixes and updates for Pharo 10, incl. usage of Spec2 instead of Spec1.

Partially fixes https://github.com/magritte-metamodel/magritte/issues/294
- [x] MAMorphicDropList>>#buildMorphView uses DropListModel from Spec1
- [x] MAMorphicDate>>#buildMorphView uses DateModelfrom Spec1
- [x] TokenCollectorMorph>>#textInput uses TextInputFieldModel from Spec1

Makes Magritte compatible with Pharo 10+, but **incompatible with Pharo 8-**. Might be advisable to create separate branch for Pharo 10+ or Pharo8-