### PR TITLE
[Bug]: Bloc Form To-One Tokens Pointing to Copy

### DIFF
--- a/source/Magritte-GToolkit/MATokenSelectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenSelectorElement.class.st
@@ -89,7 +89,7 @@ MATokenSelectorElement >> refreshTokens [
 
 	| currentValue |
 	self tokenContainer removeChildren.
-	currentValue := self object readUsing: self relationDescription.
+	currentValue := self object readModelUsing: self relationDescription.
 	currentValue ifNotNil: [ self addTokenFor: currentValue ].
 ]
 

--- a/source/Magritte-Model/MAMemento.class.st
+++ b/source/Magritte-Model/MAMemento.class.st
@@ -94,8 +94,10 @@ MAMemento >> pullRaw [
 	self magritteDescription do: [ :each |
 		| value |
 		value := self model readUsing: each.
-		result at: each put: value copy ].
+		result at: each put: value copy "see implementation note" ].
 	^ result
+	
+	"Implementation note: We copy the field values because checked mementos compare the `original` pull to the current object to see if it has changed elsewhere. Unless we make a copy each time, this comparison would not be possible for complex objects, because any changes to them from outside will be reflected equally in the `original` dictionary. E.g. if `original at: #person == self model person` and outside someone does `self model person age: 25`, the check above would pass even though it should fail."
 ]
 
 { #category : #private }
@@ -105,6 +107,11 @@ MAMemento >> push: aDictionary [
 	aDictionary keysAndValuesDo: [ :key :value |
 		(self shouldPush: value using: key) 
 			ifTrue: [ self model write: value using: key ] ]
+]
+
+{ #category : #private }
+MAMemento >> readModelUsing: aDescription [
+	^ self model readUsing: aDescription
 ]
 
 { #category : #private }

--- a/source/Magritte-Model/Object.extension.st
+++ b/source/Magritte-Model/Object.extension.st
@@ -148,6 +148,13 @@ Object >> mementoClass [
 ]
 
 { #category : #'*Magritte-Model' }
+Object >> readModelUsing: aDescription [
+	"This makes Object and MACheckedMemento polymorphic. It is needed e.g. for Magritte forms because inspectable field values should open on the actual object, not the memento's copies. See MAMemento>>#pullRaw for more info"
+
+	^ self readUsing: aDescription
+]
+
+{ #category : #'*Magritte-Model' }
 Object >> readUsing: aDescription [
 	"This hook is needed so that e.g. mementos and adaptive models can implement their own behavior. All other entry points e.g. MADescription>>#read: should come through here"
 


### PR DESCRIPTION
As a result of #296, memento fields are copies of the model state. Bloc tokens were not updated to this new strategy, and thus were pointing to these copies instead of the actual state. When they were clicked, an inspector would open on a temporary copy, not the object actually held by the model.