### PR TITLE
[Enh]: Mementos - Only Copy Checked Original

### DIFF
--- a/source/Magritte-GToolkit/MATokenSelectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenSelectorElement.class.st
@@ -89,7 +89,7 @@ MATokenSelectorElement >> refreshTokens [
 
 	| currentValue |
 	self tokenContainer removeChildren.
-	currentValue := self object readModelUsing: self relationDescription.
+	currentValue := self object readUsing: self relationDescription.
 	currentValue ifNotNil: [ self addTokenFor: currentValue ].
 ]
 

--- a/source/Magritte-Model/MACheckedMemento.class.st
+++ b/source/Magritte-Model/MACheckedMemento.class.st
@@ -30,7 +30,9 @@ MACheckedMemento >> original [
 { #category : #actions }
 MACheckedMemento >> reset [
 	super reset.
-	self setOriginal: self pullRaw
+	self setOriginal: (self pullRawTransforming: [ :e | e copy ]).
+	
+	"Implementation note: We copy the field values because checked mementos compare this to the current object to see if it has changed elsewhere. Unless we make a copy each time, this comparison would not be possible for complex objects, because any changes to them from outside will be reflected equally in this `original` dictionary. E.g. if `original at: #person == self model person` and outside someone does `self model person age: 25`, the check above would pass even though it should fail."
 ]
 
 { #category : #initialization }

--- a/source/Magritte-Model/MAMemento.class.st
+++ b/source/Magritte-Model/MAMemento.class.st
@@ -89,15 +89,20 @@ MAMemento >> pull [
 
 { #category : #private }
 MAMemento >> pullRaw [
+	
+	^ self pullRawTransforming: [ :e | e ]
+]
+
+{ #category : #private }
+MAMemento >> pullRawTransforming: aBlock [
 	| result |
 	result := Dictionary new.
 	self magritteDescription do: [ :each |
-		| value |
+		| value transformedValue |
 		value := self model readUsing: each.
-		result at: each put: value copy "see implementation note" ].
+		transformedValue := aBlock value: value.
+		result at: each put: transformedValue ].
 	^ result
-	
-	"Implementation note: We copy the field values because checked mementos compare the `original` pull to the current object to see if it has changed elsewhere. Unless we make a copy each time, this comparison would not be possible for complex objects, because any changes to them from outside will be reflected equally in the `original` dictionary. E.g. if `original at: #person == self model person` and outside someone does `self model person age: 25`, the check above would pass even though it should fail."
 ]
 
 { #category : #private }
@@ -107,11 +112,6 @@ MAMemento >> push: aDictionary [
 	aDictionary keysAndValuesDo: [ :key :value |
 		(self shouldPush: value using: key) 
 			ifTrue: [ self model write: value using: key ] ]
-]
-
-{ #category : #private }
-MAMemento >> readModelUsing: aDescription [
-	^ self model readUsing: aDescription
 ]
 
 { #category : #private }

--- a/source/Magritte-Model/Object.extension.st
+++ b/source/Magritte-Model/Object.extension.st
@@ -148,13 +148,6 @@ Object >> mementoClass [
 ]
 
 { #category : #'*Magritte-Model' }
-Object >> readModelUsing: aDescription [
-	"This makes Object and MACheckedMemento polymorphic. It is needed e.g. for Magritte forms because inspectable field values should open on the actual object, not the memento's copies. See MAMemento>>#pullRaw for more info"
-
-	^ self readUsing: aDescription
-]
-
-{ #category : #'*Magritte-Model' }
 Object >> readUsing: aDescription [
 	"This hook is needed so that e.g. mementos and adaptive models can implement their own behavior. All other entry points e.g. MADescription>>#read: should come through here"
 


### PR DESCRIPTION
We were *always* copying field values when pulling so that the `original` could query whether the model had changed elsewhere. However, this created complication in other contexts (e.g. display of current data) where you want the real objects. So we simplify and only copy for the one use case where we currently need it (otherwise just use the real objects)