### PR TITLE
[Enh]: GT Search Transform

### DIFF
--- a/source/Magritte-GToolkit/MATokenSelectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenSelectorElement.class.st
@@ -45,8 +45,11 @@ MATokenSelectorElement >> initialize [
 	searchButton := GtSpotterDropdownButtonStencil new
 			valuable: [ self relationDescription gtSearchSource value ];
 			icon: BrGlamorousVectorIcons search;
-			actOn: [ :anActOnEvent :anItem :theButton | 
-				self onTokenRequestFor: anActOnEvent objectToSend.
+			actOn: [ :anActOnEvent :anItem :theButton |
+				| result spottedObject |
+				spottedObject := anActOnEvent objectToSend.
+				result := self relationDescription gtSearchTransform value: spottedObject.
+				self onTokenRequestFor: result.
 				anActOnEvent beActed ];
 			create.
 

--- a/source/Magritte-Model/MAReferenceDescription.class.st
+++ b/source/Magritte-Model/MAReferenceDescription.class.st
@@ -91,6 +91,16 @@ MAReferenceDescription >> gtSearchSource: valuable [
 ]
 
 { #category : #accessing }
+MAReferenceDescription >> gtSearchTransform [
+	^ self propertyAt: #gtSearchTransform ifAbsent: #yourself
+]
+
+{ #category : #accessing }
+MAReferenceDescription >> gtSearchTransform: valuable [
+	self propertyAt: #gtSearchTransform put: valuable
+]
+
+{ #category : #accessing }
 MAReferenceDescription >> initializer [
 	^ self propertyAt: #initializer ifAbsent: [ #yourself ]
 ]


### PR DESCRIPTION
For reference descriptions, a way to supplement the send block of a gt search source. Useful e.g. if you need to establish a parent/child relationship or do other configuration not anticipated by the source spotter writer