### PR TITLE
[WIP]: Bloc Token Labels - Use Display String

### DIFF
--- a/source/Magritte-GToolkit/MADropdownElement.class.st
+++ b/source/Magritte-GToolkit/MADropdownElement.class.st
@@ -6,7 +6,7 @@ Class {
 		'selection',
 		'itemDescription'
 	],
-	#category : 'Magritte-GToolkit-Widgets'
+	#category : #'Magritte-GToolkit-Widgets'
 }
 
 { #category : #accessing }
@@ -144,7 +144,9 @@ MADropdownElement >> selection: anObject [
 
 { #category : #accessing }
 MADropdownElement >> selectionString [
-	^ self itemDescription toString: self selection
+	^ self selection 
+		ifNil: [ '' ]
+		ifNotNil: [ :sel | sel gtDisplayText ]
 ]
 
 { #category : #accessing }

--- a/source/Magritte-GToolkit/MATokenSelectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenSelectorElement.class.st
@@ -23,7 +23,7 @@ MATokenSelectorElement >> addTokenFor: anObject [
 	
 	| token |
 	token := MATokenElement new
-		label: (self relationDescription reference toString: anObject);
+		label: anObject gtDisplayText;
 		object: anObject;
 		removeAction: [ :obj | self onTokenRemovedFor: obj ];
 		yourself.


### PR DESCRIPTION
We don't yet have a flexible mechanism to adjust the display string/text via the description, as described by #310 and #311, so use `#gtDisplayText` for now, which at least is better than a print string