### PR TITLE
Made loadable in Pharo 11 and 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Magritte is a fully dynamic meta-description framework that helps to solve those
 
 ### Installation
   * [Pharo Smalltalk](http://www.pharo.org/):
-    * Pharo 6.x - 8.x: 
+    * Pharo 6.x - 11.x: 
     ```smalltalk
     Metacello new
       baseline: 'Magritte';
@@ -27,11 +27,11 @@ In you project Baseline or Configuration definition, add to the spec:
 
 ```
 baseline: 'Magritte' 
-with: [ spec repository: 'github://magritte-metamodel/magritte:v3.5.4'; 
+with: [ spec repository: 'github://magritte-metamodel/magritte:v3.8'; 
              loads: #(Core) ]; 
 ```
 
-This snippet uses V3.5.4 release version, remember to change the release version to your needs. See BaselineOfMagritte for other groups to load beside of 'Core'.
+This snippet uses v3.8 release version, remember to change the release version to your needs. See BaselineOfMagritte for other groups to load beside of 'Core'.
 
 ### Mailing-Lists
   * [Magritte, Pier and Related Tools](https://www.iam.unibe.ch/mailman/listinfo/smallwiki)

--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -34,7 +34,7 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 	"Common external dependencies for baseline 3.1.0"
 	
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.9.0/repository' ];	
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.12.0/repository' ];	
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec

--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -45,7 +45,7 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 { #category : #baselines }
 BaselineOfMagritte >> baseline330ForPharo: spec [
 			
-	spec for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x' #'pharo10.x') do: [ 
+	spec for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x' #'pharo10.x' #'pharo11.x' #'pharo12.x') do: [
 		spec 
 			baseline: 'PharoEnhancements' with: [ spec repository: 'github://seandenigris/Pharo-Enhancements' ].
 		spec


### PR DESCRIPTION
Modified baseline to make Magritte loadable in Pharo 11 and 12 and modified README to mention Pharo 9+.
Yet loadable does not mean fully working and tested. It works in Pharo 11 for OpenPonk that uses small subset of Magritte features, but nothing else was actually used there.