### PR TITLE
[Clean]: Extract UID Property Support to Dynabook Foundation

### DIFF
--- a/source/Magritte-Model/MATPropertyOwner.trait.st
+++ b/source/Magritte-Model/MATPropertyOwner.trait.st
@@ -6,14 +6,6 @@ Trait {
 	#category : #'Magritte-Model-Core'
 }
 
-{ #category : #uuid }
-MATPropertyOwner >> ensureUUID [
-	"See #uuid comment"
-	 ^ self 
-	 	propertyAt: #uuid
-	 	ifAbsentPut: [ UUIDGenerator next ]
-]
-
 { #category : #private }
 MATPropertyOwner >> errorPropertyNotFound: aSelector [ 
 	MAPropertyError signal: 'Property ' , aSelector , ' not found.'
@@ -200,21 +192,6 @@ MATPropertyOwner >> unsubscribe: aSubscriber [
 		ifPresent: [ :anAnnouncer | 
 			anAnnouncer unsubscribe: aSubscriber ]
 		ifAbsent: [  "ignore" ]
-]
-
-{ #category : #uuid }
-MATPropertyOwner >> uuid [
-	
-	 ^ self propertyAt: #uuid ifAbsent: [ nil ]
-	"It is a stretch to place this in MATPropertyOwner, but it's only two methods, so in the interest of simplicity we'll put it here until someone complains. We had extracted this to ObjectiveLepiter, the only user. However, due to limitations in Pharo packaging, namely lack of extension traits, users become unusable unless in GT, where OL works. For now, it seems prudent to live with the two methods in question to make life easier"
-]
-
-{ #category : #uuid }
-MATPropertyOwner >> uuid: aUUID [
-
-	self 
-		propertyAt: #uuid
-		put: aUUID
 ]
 
 { #category : #subscriptions }


### PR DESCRIPTION
UID stuff moved out of `MATPropertyOwner`