### PR TITLE
[Enh]: Element Descriptions - Initial Answer

### DIFF
--- a/source/Magritte-Model/MADescription.class.st
+++ b/source/Magritte-Model/MADescription.class.st
@@ -879,9 +879,10 @@ MADescription >> undefined: aString [
 
 { #category : #'accessing-properties' }
 MADescription >> undefinedValue [
-	self flag: 'could this be simplified with maLazyXyz?'.
-	^ (self propertyAt: #undefinedValue ifAbsent: [ self class defaultUndefinedValue ])
-		ifNil: [ self class defaultUndefinedValue ]
+
+	^ self 
+		propertyAt: #undefinedValue 
+		ifAbsent: [ self class defaultUndefinedValue ]
 ]
 
 { #category : #'accessing-properties' }

--- a/source/Magritte-Model/MAElementDescription.class.st
+++ b/source/Magritte-Model/MAElementDescription.class.st
@@ -85,6 +85,16 @@ MAElementDescription >> handlesSelector: aSelector [
 	^ self accessor handlesSelector: aSelector
 ]
 
+{ #category : #accessing }
+MAElementDescription >> initialAnswer [
+	^ self propertyAt: #initialAnswer ifAbsent: [ self default ]
+]
+
+{ #category : #accessing }
+MAElementDescription >> initialAnswer: aValuable [
+	self propertyAt: #initialAnswer put: aValuable
+]
+
 { #category : #'lazy initialization' }
 MAElementDescription >> lazilyInitializeFrom: currentValue for: anObject [
 	"- The default value is cached if the description's #shouldCacheDefault property is true. An example when caching is necessary is for to-many relations because the user may modify the collection, which will then be thrown away if not cached


### PR DESCRIPTION
- Slightly different than `default`. Default is what the value of the field *is* if not explicitly set. The initial answer is what the value *might be* e.g. to make it easier to fill out a form.
- Also remove a duplicated statement that was a no-op