### PR TITLE
Checked Memento raises errors for Pier components 

### DIFF
--- a/source/Magritte-Model/MACheckedMemento.class.st
+++ b/source/Magritte-Model/MACheckedMemento.class.st
@@ -29,9 +29,9 @@ MACheckedMemento >> original [
 
 { #category : #actions }
 MACheckedMemento >> reset [
-	super reset.
-	self setOriginal: (self pullRawTransforming: [ :e | e copy ]).
-	
+        super reset.
+        self setOriginal: (self pullRawTransforming: [ :e | e isBehavior ifTrue: [ e ] ifFalse: [ e copy ] ])
+
 	"Implementation note: We copy the field values because checked mementos compare this to the current object to see if it has changed elsewhere. Unless we make a copy each time, this comparison would not be possible for complex objects, because any changes to them from outside will be reflected equally in this `original` dictionary. E.g. if `original at: #person == self model person` and outside someone does `self model person age: 25`, the check above would pass even though it should fail."
 ]
 

--- a/source/Magritte-Tests-Model/MACheckedMementoTest.class.st
+++ b/source/Magritte-Tests-Model/MACheckedMementoTest.class.st
@@ -14,6 +14,14 @@ MACheckedMementoTest >> actualClass [
 	^ MACheckedMemento
 ]
 
+{ #category : #'tests-accessing' }
+MACheckedMementoTest >> testClassHasModelChangedElsewhere [
+        self value: self class.
+        self memento reset.
+        self deny: self memento hasModelChangedElsewhere
+
+]
+
 { #category : #'tests-actions' }
 MACheckedMementoTest >> testConflictCommit [
 	self write: self includedInstance.


### PR DESCRIPTION
A test and change for memento - https://www.myborden.com/pier/john-c-borden/updates/input-is-conflicting-with-concurrent-modification