### PR TITLE
[Bug]: action comparison

### DIFF
--- a/source/Magritte-Model/MAActionDescription.class.st
+++ b/source/Magritte-Model/MAActionDescription.class.st
@@ -34,7 +34,7 @@ MAActionDescription >> <= anObject [
 
 { #category : #comparing }
 MAActionDescription >> = anObject [
-	^ super = anObject and: [ self action = anObject action ]
+	^ self == anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
We were only looking at part of the state - species and action - which caused some actions to overshadow others. In fact, since these are mutable, we are better off sticking with identity comparison. Supersedes #345