### PR TITLE
[Clean]: Validation Error Catching should be in Validator Visitor

### DIFF
--- a/source/Magritte-Model/MAValidatorVisitor.class.st
+++ b/source/Magritte-Model/MAValidatorVisitor.class.st
@@ -48,9 +48,24 @@ MAValidatorVisitor >> validate: anObject using: aDescription [
 MAValidatorVisitor >> visit: aDescription [
 	"Only visit objects that are visible and that can be changed."
 	
+	| errors |
 	(aDescription isVisible and: [ aDescription isReadOnly not ])
-		ifTrue: [ super visit: aDescription ].
-	
+		ifFalse: [ ^ self ].
+
+	errors := OrderedCollection new.
+	[ 
+		super visit: aDescription
+	]
+		on: MAValidationError
+		do: [ :err | 
+			errors add: err. 
+			err resume ].
+		
+	errors isEmpty ifFalse: [
+		MAMultipleErrors
+			description: aDescription 
+			errors: errors
+			signal: aDescription label ]
 ]
 
 { #category : #'visiting-descriptions' }

--- a/source/Magritte-Model/MAVisitor.class.st
+++ b/source/Magritte-Model/MAVisitor.class.st
@@ -36,21 +36,8 @@ MAVisitor class >> buildVisitorHierarchyForClass: aClass selector: aBlock classi
 { #category : #visiting }
 MAVisitor >> visit: anObject [
 	"Visit ==anObject== with the receiving visitor."
-	| errors |
-	errors := OrderedCollection new.
-	[
-		anObject acceptMagritte: self.
-	]
-		on: MAValidationError
-		do: [ :err | 
-			errors add: err. 
-			err resume ].
-		
-	errors isEmpty ifFalse: [
-		MAMultipleErrors
-			description: anObject 
-			errors: errors
-			signal: anObject label ]
+	
+	anObject acceptMagritte: self.
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
For some reason, it was implemented in MAVisitor, even thought it doesn't apply to any other subclass