### PR TITLE
Updated Grease to v1.18.0

### DIFF
--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -34,7 +34,7 @@ BaselineOfMagritte >> baseline310CommonExtDeps: spec [
 	"Common external dependencies for baseline 3.1.0"
 	
 	spec
-		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.12.0/repository' ];	
+		baseline: 'Grease' with: [ spec repository: 'github://SeasideSt/Grease:v1.18.0/repository' ];	
 		baseline: 'Seaside3'
 			with: [ "note: we do not want to depend on Zinc, since this is not present in Squeak. Currently no adapter is loaded"
 			spec


### PR DESCRIPTION
Allows loading into Pharo 12.

May help with https://github.com/magritte-metamodel/magritte/issues/342#issuecomment-1975193958 (not with the original issue, just the unrelated problem in the linked comment)