### PR TITLE
[Enh]: Number Reading - Thousands Separators

### DIFF
--- a/source/Magritte-Model/MANumberDescription.class.st
+++ b/source/Magritte-Model/MANumberDescription.class.st
@@ -12,6 +12,12 @@ MANumberDescription class >> defaultKind [
 	^ Number
 ]
 
+{ #category : #'accessing-defaults' }
+MANumberDescription class >> defaultThousandsSeparator [
+
+	^ $,
+]
+
 { #category : #testing }
 MANumberDescription class >> isAbstract [
 	^ false
@@ -40,4 +46,20 @@ MANumberDescription >> beNegative [
 { #category : #convenience }
 MANumberDescription >> bePositive [
 	self addCondition: (MACondition selector: #positive) labelled: 'No positive number was entered'
+]
+
+{ #category : #accessing }
+MANumberDescription >> thousandsSeparator [
+
+	^ self 
+		propertyAt: #thousandsSeparator
+		ifAbsent: [ self class defaultThousandsSeparator ]
+]
+
+{ #category : #accessing }
+MANumberDescription >> thousandsSeparator: aCharacter [
+
+	^ self 
+		propertyAt: #thousandsSeparator
+		putRemovingNil: aCharacter
 ]

--- a/source/Magritte-Model/MAStringReader.class.st
+++ b/source/Magritte-Model/MAStringReader.class.st
@@ -114,9 +114,12 @@ MAStringReader >> visitMultipleOptionDescription: aDescription [
 
 { #category : #'visiting-description' }
 MAStringReader >> visitNumberDescription: aDescription [
-	| isContentsValid |
-	isContentsValid := NumberParser isValidNumber: self contents.
+	| isContentsValid cleanedContents |
+	cleanedContents := self contents reject: [ :e | e = aDescription thousandsSeparator ].
+	isContentsValid := NumberParser isValidNumber: cleanedContents.
 	isContentsValid ifFalse: [ MAReadError signal ].
+	
+	self stream: cleanedContents readStream.
 	super visitNumberDescription: aDescription
 ]
 

--- a/source/Magritte-Tests-Model/MANumberDescriptionTest.class.st
+++ b/source/Magritte-Tests-Model/MANumberDescriptionTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #MANumberDescriptionTest,
 	#superclass : #MAMagnitudeDescriptionTest,
-	#category : 'Magritte-Tests-Model-Description'
+	#category : #'Magritte-Tests-Model-Description'
 }
 
 { #category : #testing }
@@ -83,6 +83,25 @@ MANumberDescriptionTest >> testFromString [
 	self assert: (self description fromString: '') isNil description: 'Empty string should be parsed to nil'.
 	self assert: (self description fromString: '-20')
 			= -20 description: 'Negative numbers should be accepted'
+]
+
+{ #category : #private }
+MANumberDescriptionTest >> testThousandsSeparatorCustom [
+	
+	self 
+		assert: (self description
+			thousandsSeparator: $.;
+			fromString: '20.000')
+		equals: 20000 "By default, commas should be ignored"
+]
+
+{ #category : #private }
+MANumberDescriptionTest >> testThousandsSeparatorDefault [
+	
+	"self assert: (self description fromString: '') isNil description: 'Empty string should be parsed to nil'."
+	self 
+		assert: (self description fromString: '20,000')
+		equals: 20000 "By default, commas should be ignored"
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Reads strings like `10,000` (the default) or change to `10.000`