### PR TITLE
[Enh]: GT Form Tokens should Flow

### DIFF
--- a/source/Magritte-GToolkit/MATokenSelectorElement.class.st
+++ b/source/Magritte-GToolkit/MATokenSelectorElement.class.st
@@ -110,8 +110,8 @@ MATokenSelectorElement >> relationDescription: anObject [
 MATokenSelectorElement >> tokenContainer [
 	tokenContainer ifNotNil: [ ^ tokenContainer ].
 	
-	^ tokenContainer := BrHorizontalPane new
+	^ tokenContainer := BrHorizontalFlow new
 		vFitContent;
-		hFitContent;
+		hMatchParent;
 		yourself
 ]


### PR DESCRIPTION
Before, if there were many multiple options or to-many relation items, they would often run off the screen and get clipped:
<img width="825" alt="Screenshot 2024-09-10 at 8 29 18 PM" src="https://github.com/user-attachments/assets/57decbab-a509-44a7-8115-6526379ba621">

After, they flow down to stay within the container horizontally:
<img width="813" alt="Screenshot 2024-09-10 at 8 29 49 PM" src="https://github.com/user-attachments/assets/def3824f-67f3-4709-a1f0-0696a45c1c2b">
