### PR TITLE
Updating Magritte baseline for pharo13 compatibility

### DIFF
--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -145,7 +145,8 @@ BaselineOfMagritte >> customProjectAttributes [
 
 { #category : #testing }
 BaselineOfMagritte >> isGTImage [
-	
-	^ RPackageOrganizer default packageNames anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ].
+	(Smalltalk at: #'RPackageOrganizer' ifAbsent: [ nil ])
+	   ifNil: [ ^ self packageOrganizer packageNames anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ] ]
+           ifNotNil: [ ^ RPackageOrganizer default packageNams anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ] ]
 	"Implementation note: used to check for GToolkit prefix, but P7 has a GToolkit-Examples package. Lepiter, OTOH, could only be loaded in a GT image"
 ]

--- a/source/Magritte-GemStone-Seaside/MAExternalFileModel.extension.st
+++ b/source/Magritte-GemStone-Seaside/MAExternalFileModel.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #MAExternalFileModel }
-
-{ #category : #'*magritte-gemstone-seaside-accessing' }
-MAExternalFileModel >> url [
-	^ self baseUrl isNil
-		ifTrue: [ super url ]
-		ifFalse: [ self baseUrl , '/' , (self location reduce: [ :a :b | a , '/' , b ]) , '/' , self filename ]
-]

--- a/source/Magritte-Pharo-Seaside/MAExternalFileModel.extension.st
+++ b/source/Magritte-Pharo-Seaside/MAExternalFileModel.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #MAExternalFileModel }
-
-{ #category : #'*magritte-pharo-seaside-accessing' }
-MAExternalFileModel >> url [
-	^ self baseUrl isNil
-		ifTrue: [ super url ]
-		ifFalse: [ self baseUrl , '/' , (self location reduce: [ :a :b | a , '/' , b ]) , '/' , self filename ]
-]


### PR DESCRIPTION
Updting customProjectAttributes in order to be compatible with Pharo 13.  RPackageOrganizer was removed in Pharo 13.