### PR TITLE
Removing url from Gemstone-/Pharo-Seaside from external model extension

### DIFF
--- a/source/Magritte-GemStone-Seaside/MAExternalFileModel.extension.st
+++ b/source/Magritte-GemStone-Seaside/MAExternalFileModel.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #MAExternalFileModel }
-
-{ #category : #'*magritte-gemstone-seaside-accessing' }
-MAExternalFileModel >> url [
-	^ self baseUrl isNil
-		ifTrue: [ super url ]
-		ifFalse: [ self baseUrl , '/' , (self location reduce: [ :a :b | a , '/' , b ]) , '/' , self filename ]
-]

--- a/source/Magritte-Pharo-Seaside/MAExternalFileModel.extension.st
+++ b/source/Magritte-Pharo-Seaside/MAExternalFileModel.extension.st
@@ -1,8 +1,0 @@
-Extension { #name : #MAExternalFileModel }
-
-{ #category : #'*magritte-pharo-seaside-accessing' }
-MAExternalFileModel >> url [
-	^ self baseUrl isNil
-		ifTrue: [ super url ]
-		ifFalse: [ self baseUrl , '/' , (self location reduce: [ :a :b | a , '/' , b ]) , '/' , self filename ]
-]


### PR DESCRIPTION
This is identical PR as #370.  I have made a mistake when creating the fix for the baseline including this patch.

> 
> It looks like the method is superfluous from migration to github. I have found that similar method was already removed in the past on Smalltalkhub.
> 
> It was between `Magritte-Seaside-jf.314.mcz` and `Magritte-Seaside-jf.315.mcz.`
