### PR TITLE
Making BaselineOfMagritte compatible with Pharo13

### DIFF
--- a/source/BaselineOfMagritte/BaselineOfMagritte.class.st
+++ b/source/BaselineOfMagritte/BaselineOfMagritte.class.st
@@ -145,7 +145,11 @@ BaselineOfMagritte >> customProjectAttributes [
 
 { #category : #testing }
 BaselineOfMagritte >> isGTImage [
-	
-	^ RPackageOrganizer default packageNames anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ].
+	| packageOrg |
+	packageOrg := Smalltalk
+		at: #'RPackageOrganizer'
+			ifPresent: [ :cls | cls default ]
+			ifAbsent: [ self packageOrganizer ].
+	^ packageOrg packageNames anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ].
 	"Implementation note: used to check for GToolkit prefix, but P7 has a GToolkit-Examples package. Lepiter, OTOH, could only be loaded in a GT image"
 ]


### PR DESCRIPTION
Baseline can now decide which code will be used based on class presence