### PR TITLE
Removing unused method using non-existent class MIMEType

### DIFF
--- a/source/Magritte-FileSystem/MAFileSystem.class.st
+++ b/source/Magritte-FileSystem/MAFileSystem.class.st
@@ -26,11 +26,3 @@ MAFileSystem class >> imageDirectory [
 
 	^ FileLocator imageDirectory.
 ]
-
-{ #category : #'mime types' }
-MAFileSystem class >> mimeTypesForExtension: aString [ 
-
-	| types |
-	types := MIMEType forExtensionReturnMimeTypesOrNil: aString.
-	^ types ifNotNil: [ types collect: [ :e | e asString ] ].
-]

--- a/source/Magritte-Pharo3-Model/MAFileSystem.class.st
+++ b/source/Magritte-Pharo3-Model/MAFileSystem.class.st
@@ -26,11 +26,3 @@ MAFileSystem class >> imageDirectory [
 
 	^ FileLocator imageDirectory.
 ]
-
-{ #category : #'mime types' }
-MAFileSystem class >> mimeTypesForExtension: aString [ 
-
-	| types |
-	types := MIMEType forExtensionReturnMimeTypesOrNil: aString.
-	^ types ifNotNil: [ types collect: [ :e | e asString ] ].
-]


### PR DESCRIPTION
This method is unused.  The method's code references non-existing MIMEType class.