### PR TITLE
[Enh]: In GT Views, Reload Forms after Button Actions

### DIFF
--- a/source/Magritte-GToolkit/MAElementBuilder.class.st
+++ b/source/Magritte-GToolkit/MAElementBuilder.class.st
@@ -16,7 +16,8 @@ Class {
 		'buttonSelectors',
 		'objectDescription',
 		'completionControllerClass',
-		'completionStrategy'
+		'completionStrategy',
+		'toolbar'
 	],
 	#category : #'Magritte-GToolkit'
 }
@@ -268,7 +269,9 @@ MAElementBuilder >> textUsing: aDescription [
 
 { #category : #accessing }
 MAElementBuilder >> toolbar [
-	| toolbar |
+
+	toolbar ifNotNil: [ ^ toolbar ].
+	
 	toolbar := BrToolbar new
 		aptitude: BrToolbarAptitude new;
 		layout:

--- a/source/Magritte-GToolkit/Object.extension.st
+++ b/source/Magritte-GToolkit/Object.extension.st
@@ -59,7 +59,17 @@ Object >> maGtFormFor: aView [
 	^ aView explicit
 		title: 'Magritte';
 		priority: 50;
-		stencil: [ ((description elementBuilderFor: self) addButtons; element) asScrollableElement ];
+		stencil: [ 
+			| builder |
+			builder := description elementBuilderFor: self.
+			builder addButtons.
+			builder toolbar children do: [ :button |
+				| currentAction |
+				currentAction := button action.
+				button action: [ 
+					currentAction value.
+					button phlow firstParentWithViewContent phlow update ] ].
+			builder element asScrollableElement. ];
 		actionButtonIcon: BrGlamorousVectorIcons inspect
 		  label: 'Memento'
 		  tooltip: 'Inspect Memento'


### PR DESCRIPTION
- After saving, forcing, or cancelling a form, reset the fields.
- Element builder now caches the toolbar after creation so that it can be easily customized from outside.