### PR TITLE
[Bug]: "And" Conditions should Fail Quickly

### DIFF
--- a/source/Magritte-Model/MAConjunctiveCondition.class.st
+++ b/source/Magritte-Model/MAConjunctiveCondition.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'conditions'
 	],
-	#category : 'Magritte-Model-Utility'
+	#category : #'Magritte-Model-Utility'
 }
 
 { #category : #operators }
@@ -19,5 +19,10 @@ MAConjunctiveCondition >> initialize [
 
 { #category : #evaluating }
 MAConjunctiveCondition >> value: anObject [
-	^ conditions allSatisfy: [ :each | each value: anObject ]
+
+	conditions 
+		detect: [ :each | (each value: anObject) not ]
+		ifFound: [ ^ false ].
+		
+	^ true
 ]


### PR DESCRIPTION
Right now, "and" conditions use `allSatisfy:`. This means that every condition will be evaluated. The problem arises with this common pattern: `[ anObject isSafe ] and: [ anObject doRiskyThing ]`, which relies on the second test not being performed if the first fails.